### PR TITLE
Enhance generic Get/MustGet with Duration support and improve tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,15 @@
 name: Build
-
 on: push
-
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.19','1.20','1.21','1.22', '1.23', '1.24' ]
+        go: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24', '1.25', '1.26']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - run: go build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24', '1.25', '1.26']
+        go: ['1.21', '1.22', '1.23', '1.24', '1.25', '1.26']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,18 @@
 name: Lint
-
 on: push
-
 permissions:
   contents: read
-
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
-      - uses: golangci/golangci-lint-action@v8
+          go-version: '1.26'
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.12
           only-new-issues: true
           skip-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24', '1.25', '1.26']
+        go: ['1.21', '1.22', '1.23', '1.24', '1.25', '1.26']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,15 @@
 name: Test and Coverage
-
 on: push
-
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.19','1.20','1.21','1.22', '1.23', '1.24' ]
+        go: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24', '1.25', '1.26']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: Run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# Editor files
 .idea/
+.vscode/
+
+# Go
 coverage.out

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,17 +8,17 @@ linters:
     - wsl
     - copyloopvar
     - intrange
+    - gomodguard
+    - goconst
     - cyclop
     - depguard
     - dupl
     - forcetypeassert
     - funlen
-    - nlreturn
     - ireturn
     - maintidx
     - nonamedreturns
     - paralleltest
-    - revive
     - varnamelen
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,21 +5,21 @@ run:
 linters:
   default: all
   disable:
-  - wsl
-  - copyloopvar
-  - intrange
-  - cyclop
-  - depguard
-  - dupl
-  - forcetypeassert
-  - funlen
-  - nlreturn
-  - ireturn
-  - maintidx
-  - nonamedreturns
-  - paralleltest
-  - revive
-  - varnamelen
+    - wsl
+    - copyloopvar
+    - intrange
+    - cyclop
+    - depguard
+    - dupl
+    - forcetypeassert
+    - funlen
+    - nlreturn
+    - ireturn
+    - maintidx
+    - nonamedreturns
+    - paralleltest
+    - revive
+    - varnamelen
 formatters:
   enable:
     - gci

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/nasermirzaei89/env"
 )
@@ -41,6 +42,9 @@ func main() {
 	s := env.GetString("B", "hi")
 	fmt.Println(s) // hi (default)
 
+	d := env.GetDuration("D", 5*time.Second)
+	fmt.Println(d) // 5s (default)
+
 	// Generics
 
 	b2 := env.Get("A", true)
@@ -54,6 +58,9 @@ func main() {
 
 	s2 := env.Get("B", "hi")
 	fmt.Println(s2) // hi (default)
+
+	d2 := env.Get("D", 5*time.Second)
+	fmt.Println(d2) // 5s (default)
 }
 ```
 
@@ -64,6 +71,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/nasermirzaei89/env"
 )
@@ -74,12 +82,22 @@ func main() {
 
 	s = env.MustGetString("NEW") // panics
 
+	d := env.MustGetDuration("TIMEOUT")
+	fmt.Println(d) // e.g. 30s
+
+	d = env.MustGetDuration("NEW") // panics
+
 	// Generics
 
 	s2 := env.MustGet[string]("HOME")
 	fmt.Println(s2) // /Users/nasermirzaei89
 
 	s2 = env.MustGet[string]("NEW") // panics
+
+	d2 := env.MustGet[time.Duration]("TIMEOUT")
+	fmt.Println(d2) // e.g. 30s
+
+	d2 = env.MustGet[time.Duration]("NEW") // panics
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ func main() {
 	d := env.GetDuration("D", 5*time.Second)
 	fmt.Println(d) // 5s (default)
 
-	// Generics
+	// With generics
 
 	b2 := env.Get("A", true)
 	fmt.Println(b2) // true (default)
@@ -98,6 +98,46 @@ func main() {
 	fmt.Println(d2) // e.g. 30s
 
 	d2 = env.MustGet[time.Duration]("NEW") // panics
+}
+```
+
+### Lookup with structured errors
+
+`LookupXXX` returns the value and an `error`. Use `errors.As` to distinguish between a missing key (`NotSetError`) and an unparseable value (`InvalidValueError`).
+
+```go
+package main
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nasermirzaei89/env"
+)
+
+func main() {
+	// Typed lookup
+	v, err := env.LookupInt("PORT")
+	if err != nil {
+		var notSet env.NotSetError
+		var invalid env.InvalidValueError
+
+		switch {
+		case errors.As(err, &notSet):
+			fmt.Printf("%q is not set\n", notSet.Key)
+		case errors.As(err, &invalid):
+			fmt.Printf("%q has invalid value %q: %v\n", invalid.Key, invalid.Value, invalid.Err)
+		}
+	} else {
+		fmt.Println("PORT =", v)
+	}
+
+	// Generic lookup
+	s, err := env.Lookup[string]("HOME")
+	if err == nil {
+		fmt.Println("HOME =", s)
+	}
 }
 ```
 

--- a/assert_test.go
+++ b/assert_test.go
@@ -2,6 +2,7 @@ package env_test
 
 import (
 	"runtime/debug"
+	"slices"
 	"testing"
 )
 
@@ -34,20 +35,7 @@ func assertFalse(t *testing.T, value bool) {
 func assertEqualSlices[T comparable](t *testing.T, expected, actual []T) {
 	t.Helper()
 
-	var equal bool
-
-	if len(actual) == len(expected) {
-		equal = true
-
-		for i := range actual {
-			if actual[i] != expected[i] {
-				equal = false
-				break
-			}
-		}
-	}
-
-	if !equal {
+	if !slices.Equal(expected, actual) {
 		t.Errorf("expected: %#v\n actual: %#v", expected, actual)
 	}
 }
@@ -60,6 +48,16 @@ func assertPanics(t *testing.T, f func()) {
 	}
 
 	t.Error("expected panic")
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		return
+	}
+
+	t.Errorf("unexpected error: %v", err)
 }
 
 func didPanic(f func()) (funcDidPanic bool, message any, stack string) {

--- a/bool.go
+++ b/bool.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-// GetBool extracts bool value from env. if not set, returns default value.
+// GetBool extracts bool value from env. If not set, returns default value.
 func GetBool(key string, def bool) bool {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,11 +15,11 @@ func GetBool(key string, def bool) bool {
 	return s == "" || s == "1" || s == "true"
 }
 
-// MustGetBool extracts bool value from env. if not set, it panics.
+// MustGetBool extracts bool value from env. If not set, it panics.
 func MustGetBool(key string) bool {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' has not been set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	return s == "" || s == "1" || s == "true"

--- a/bool.go
+++ b/bool.go
@@ -1,26 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
+	"strconv"
 )
+
+// LookupBool extracts bool value from env. If not set, returns NotSetError.
+// If the value cannot be parsed as bool, returns InvalidValueError.
+func LookupBool(key string) (bool, error) {
+	s, ok := os.LookupEnv(key)
+	if !ok {
+		return false, NotSetError{Key: key}
+	}
+
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, InvalidValueError{Key: key, Value: s, Err: err}
+	}
+
+	return v, nil
+}
 
 // GetBool extracts bool value from env. If not set, returns default value.
 func GetBool(key string, def bool) bool {
-	s, ok := os.LookupEnv(key)
-	if !ok {
+	v, err := LookupBool(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
 		return def
 	}
 
-	return s == "" || s == "1" || s == "true"
+	panic(err)
 }
 
 // MustGetBool extracts bool value from env. If not set, it panics.
 func MustGetBool(key string) bool {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupBool(key)
+	if err != nil {
+		panic(err)
 	}
 
-	return s == "" || s == "1" || s == "true"
+	return v
 }

--- a/bool_test.go
+++ b/bool_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -36,8 +37,9 @@ func TestGetBool(t *testing.T) {
 	t.Run("GetEmptyAsBoolWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "")
 
-		res := env.GetBool("V1", false)
-		assertTrue(t, res)
+		assertPanics(t, func() {
+			env.GetBool("V1", false)
+		})
 	})
 
 	t.Run("GetOneAsBoolWithDefault", func(t *testing.T) {
@@ -81,5 +83,34 @@ func TestMustGetBool(t *testing.T) {
 
 		res := env.MustGetBool("V1")
 		assertTrue(t, res)
+	})
+}
+
+func TestLookupBool(t *testing.T) {
+	t.Run("LookupAbsentBool", func(t *testing.T) {
+		_, err := env.LookupBool("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidBool", func(t *testing.T) {
+		t.Setenv("V1", "true")
+
+		res, err := env.LookupBool("V1")
+		assertNoError(t, err)
+		assertTrue(t, res)
+	})
+
+	t.Run("LookupInvalidBool", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupBool("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/const.go
+++ b/const.go
@@ -1,0 +1,9 @@
+package env
+
+const (
+	decimalBase = 10
+	bitSize8    = 8
+	bitSize16   = 16
+	bitSize32   = 32
+	bitSize64   = 64
+)

--- a/duration.go
+++ b/duration.go
@@ -1,0 +1,37 @@
+package env
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// GetDuration extracts duration value from env. If not set, returns default value.
+func GetDuration(key string, def time.Duration) time.Duration {
+	s, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+
+	res, err := time.ParseDuration(s)
+	if err != nil {
+		panic(fmt.Sprintf("environment variable %q has invalid duration value: %v", key, err))
+	}
+
+	return res
+}
+
+// MustGetDuration extracts duration value from env. If not set, it panics.
+func MustGetDuration(key string) time.Duration {
+	s, ok := os.LookupEnv(key)
+	if !ok {
+		panic(fmt.Sprintf("environment variable %q not set", key))
+	}
+
+	res, err := time.ParseDuration(s)
+	if err != nil {
+		panic(fmt.Sprintf("environment variable %q has invalid duration value: %v", key, err))
+	}
+
+	return res
+}

--- a/duration.go
+++ b/duration.go
@@ -1,37 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"time"
 )
 
-// GetDuration extracts duration value from env. If not set, returns default value.
-func GetDuration(key string, def time.Duration) time.Duration {
+// LookupDuration extracts duration value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupDuration(key string) (time.Duration, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
+		return 0, NotSetError{Key: key}
+	}
+
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
+	}
+
+	return v, nil
+}
+
+// GetDuration extracts duration value from env. If not set, returns default value.
+func GetDuration(key string, def time.Duration) time.Duration {
+	v, err := LookupDuration(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
 		return def
 	}
 
-	res, err := time.ParseDuration(s)
-	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has invalid duration value: %v", key, err))
-	}
-
-	return res
+	panic(err)
 }
 
 // MustGetDuration extracts duration value from env. If not set, it panics.
 func MustGetDuration(key string) time.Duration {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	res, err := time.ParseDuration(s)
+	v, err := LookupDuration(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has invalid duration value: %v", key, err))
+		panic(err)
 	}
 
-	return res
+	return v
 }

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,0 +1,39 @@
+package env_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nasermirzaei89/env"
+)
+
+func TestGetDuration(t *testing.T) {
+	def := time.Second
+
+	t.Run("GetAbsentDurationWithDefault", func(t *testing.T) {
+		res := env.GetDuration("V1", def)
+		assertEqual(t, def, res)
+	})
+
+	t.Run("GetValidDurationWithDefault", func(t *testing.T) {
+		t.Setenv("V1", "2s")
+
+		res := env.GetDuration("V1", def)
+		assertEqual(t, 2*time.Second, res)
+	})
+}
+
+func TestMustGetDuration(t *testing.T) {
+	t.Run("MustGetAbsentDuration", func(t *testing.T) {
+		assertPanics(t, func() {
+			env.MustGetDuration("V1")
+		})
+	})
+
+	t.Run("MustGetValidDuration", func(t *testing.T) {
+		t.Setenv("V1", "2s")
+
+		res := env.MustGetDuration("V1")
+		assertEqual(t, 2*time.Second, res)
+	})
+}

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -21,6 +22,14 @@ func TestGetDuration(t *testing.T) {
 		res := env.GetDuration("V1", def)
 		assertEqual(t, 2*time.Second, res)
 	})
+
+	t.Run("GetInvalidDurationWithDefault", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		assertPanics(t, func() {
+			env.GetDuration("V1", def)
+		})
+	})
 }
 
 func TestMustGetDuration(t *testing.T) {
@@ -35,5 +44,34 @@ func TestMustGetDuration(t *testing.T) {
 
 		res := env.MustGetDuration("V1")
 		assertEqual(t, 2*time.Second, res)
+	})
+}
+
+func TestLookupDuration(t *testing.T) {
+	t.Run("LookupAbsentDuration", func(t *testing.T) {
+		_, err := env.LookupDuration("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidDuration", func(t *testing.T) {
+		t.Setenv("V1", "2s")
+
+		res, err := env.LookupDuration("V1")
+		assertNoError(t, err)
+		assertEqual(t, 2*time.Second, res)
+	})
+
+	t.Run("LookupInvalidDuration", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupDuration("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/env.go
+++ b/env.go
@@ -1,3 +1,4 @@
+// Package env provides functions to work with environment variables.
 package env
 
 import (

--- a/env.go
+++ b/env.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"os"
+	"slices"
 )
 
 // Env type.
@@ -13,14 +14,6 @@ const (
 	Testing     Env = "testing"
 	Staging     Env = "staging"
 	Production  Env = "production"
-)
-
-const (
-	decimalBase = 10
-	bitSize8    = 8
-	bitSize16   = 16
-	bitSize32   = 32
-	bitSize64   = 64
 )
 
 // Environment returns ENV value in environment variables.
@@ -36,13 +29,7 @@ func Is(e1 Env, ee ...Env) bool {
 		return true
 	}
 
-	for i := range ee {
-		if ee[i] == ce {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(ee, ce)
 }
 
 // IsDevelopment checks whether ENV is development or not.

--- a/env_test.go
+++ b/env_test.go
@@ -39,13 +39,13 @@ func TestIs(t *testing.T) {
 		assertTrue(t, env.Is(env.Testing))
 	})
 
-	t.Run("Multiple Envs", func(t *testing.T) {
+	t.Run("Multiple Envs - match second", func(t *testing.T) {
 		t.Setenv("ENV", "testing")
 
 		assertTrue(t, env.Is(env.Development, env.Testing))
 	})
 
-	t.Run("Multiple Envs", func(t *testing.T) {
+	t.Run("Multiple Envs - match first", func(t *testing.T) {
 		t.Setenv("ENV", "testing")
 
 		assertTrue(t, env.Is(env.Testing, env.Development))

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,27 @@
+package env
+
+import "fmt"
+
+// NotSetError is returned by LookupXXX when the environment variable is not set.
+type NotSetError struct {
+	Key string
+}
+
+func (err NotSetError) Error() string {
+	return fmt.Sprintf("environment variable %q not set", err.Key)
+}
+
+// InvalidValueError is returned by LookupXXX when the environment variable has an invalid value.
+type InvalidValueError struct {
+	Key   string
+	Value string
+	Err   error
+}
+
+func (err InvalidValueError) Error() string {
+	return fmt.Sprintf("environment variable %q has an invalid value: %q", err.Key, err.Value)
+}
+
+func (err InvalidValueError) Unwrap() error {
+	return err.Err
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -24,19 +24,19 @@ func TestNotSetError(t *testing.T) {
 
 func TestInvalidValueError(t *testing.T) {
 	t.Run("ErrorMessage", func(t *testing.T) {
-		inner := errors.New("some parse error")
+		inner := errors.New("some parse error") //nolint:err113
 		invalidValueErr := env.InvalidValueError{Key: "MY_VAR", Value: "bad", Err: inner}
 		assertEqual(t, `environment variable "MY_VAR" has an invalid value: "bad"`, invalidValueErr.Error())
 	})
 
 	t.Run("Unwrap", func(t *testing.T) {
-		inner := errors.New("some parse error")
+		inner := errors.New("some parse error") //nolint:err113
 		invalidValueErr := env.InvalidValueError{Key: "MY_VAR", Value: "bad", Err: inner}
 		assertTrue(t, errors.Is(invalidValueErr, inner))
 	})
 
 	t.Run("ErrorsAs", func(t *testing.T) {
-		inner := errors.New("some parse error")
+		inner := errors.New("some parse error") //nolint:err113
 		err := error(env.InvalidValueError{Key: "MY_VAR", Value: "bad", Err: inner})
 
 		var invalidValueErr env.InvalidValueError

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,47 @@
+package env_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nasermirzaei89/env"
+)
+
+func TestNotSetError(t *testing.T) {
+	t.Run("ErrorMessage", func(t *testing.T) {
+		notSetErr := env.NotSetError{Key: "MY_VAR"}
+		assertEqual(t, `environment variable "MY_VAR" not set`, notSetErr.Error())
+	})
+
+	t.Run("ErrorsAs", func(t *testing.T) {
+		err := error(env.NotSetError{Key: "MY_VAR"})
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "MY_VAR", notSetErr.Key)
+	})
+}
+
+func TestInvalidValueError(t *testing.T) {
+	t.Run("ErrorMessage", func(t *testing.T) {
+		inner := errors.New("some parse error")
+		invalidValueErr := env.InvalidValueError{Key: "MY_VAR", Value: "bad", Err: inner}
+		assertEqual(t, `environment variable "MY_VAR" has an invalid value: "bad"`, invalidValueErr.Error())
+	})
+
+	t.Run("Unwrap", func(t *testing.T) {
+		inner := errors.New("some parse error")
+		invalidValueErr := env.InvalidValueError{Key: "MY_VAR", Value: "bad", Err: inner}
+		assertTrue(t, errors.Is(invalidValueErr, inner))
+	})
+
+	t.Run("ErrorsAs", func(t *testing.T) {
+		inner := errors.New("some parse error")
+		err := error(env.InvalidValueError{Key: "MY_VAR", Value: "bad", Err: inner})
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "MY_VAR", invalidValueErr.Key)
+		assertEqual(t, "bad", invalidValueErr.Value)
+	})
+}

--- a/float32.go
+++ b/float32.go
@@ -1,37 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetFloat32 extracts float32 value from env. If not set, returns default value.
-func GetFloat32(key string, def float32) float32 {
+// LookupFloat32 extracts float32 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupFloat32(key string) (float32, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseFloat(s, bitSize32)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return float32(v)
+	return float32(v), nil
+}
+
+// GetFloat32 extracts float32 value from env. If not set, returns default value.
+func GetFloat32(key string, def float32) float32 {
+	v, err := LookupFloat32(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetFloat32 extracts float32 value from env. If not set, it panics.
 func MustGetFloat32(key string) float32 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseFloat(s, bitSize32)
+	v, err := LookupFloat32(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
-	return float32(v)
+	return v
 }

--- a/float32.go
+++ b/float32.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetFloat32 extracts int value from env, if not set, returns default value.
+// GetFloat32 extracts float32 value from env. If not set, returns default value.
 func GetFloat32(key string, def float32) float32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetFloat32(key string, def float32) float32 {
 
 	v, err := strconv.ParseFloat(s, bitSize32)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return float32(v)
 }
 
-// MustGetFloat32 extracts int value from env. if not set, it panics.
+// MustGetFloat32 extracts float32 value from env. If not set, it panics.
 func MustGetFloat32(key string) float32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseFloat(s, bitSize32)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return float32(v)

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// GetFloat32Slice extracts slice of float32 value with the format "1.2,2.3,3.4" from env.
-// if not set, returns default value.
+// GetFloat32Slice extracts slice of float32 values with the format "1.2,2.3,3.4" from env.
+// If not set, returns default value.
 func GetFloat32Slice(key string, def []float32) []float32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -26,7 +26,7 @@ func GetFloat32Slice(key string, def []float32) []float32 {
 	for i := range ss {
 		v, err := strconv.ParseFloat(ss[i], bitSize32)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = float32(v)
@@ -35,11 +35,11 @@ func GetFloat32Slice(key string, def []float32) []float32 {
 	return res
 }
 
-// MustGetFloat32Slice extracts slice of float32 value with the format "1.2,2.3,3.4" from env. if not set, it panics.
+// MustGetFloat32Slice extracts slice of float32 values with the format "1.2,2.3,3.4" from env. If not set, it panics.
 func MustGetFloat32Slice(key string) []float32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -53,7 +53,7 @@ func MustGetFloat32Slice(key string) []float32 {
 	for i := range ss {
 		v, err := strconv.ParseFloat(ss[i], bitSize32)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = float32(v)

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -1,22 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetFloat32Slice extracts slice of float32 values with the format "1.2,2.3,3.4" from env.
-// If not set, returns default value.
-func GetFloat32Slice(key string, def []float32) []float32 {
+// LookupFloat32Slice extracts slice of float32 values with the format "1.2,2.3,3.4" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupFloat32Slice(key string) ([]float32, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []float32{}
+		return []float32{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -26,38 +26,37 @@ func GetFloat32Slice(key string, def []float32) []float32 {
 	for i := range ss {
 		v, err := strconv.ParseFloat(ss[i], bitSize32)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = float32(v)
 	}
 
-	return res
+	return res, nil
+}
+
+// GetFloat32Slice extracts slice of float32 values with the format "1.2,2.3,3.4" from env.
+// If not set, returns default value.
+func GetFloat32Slice(key string, def []float32) []float32 {
+	v, err := LookupFloat32Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetFloat32Slice extracts slice of float32 values with the format "1.2,2.3,3.4" from env. If not set, it panics.
 func MustGetFloat32Slice(key string) []float32 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupFloat32Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []float32{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]float32, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseFloat(ss[i], bitSize32)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = float32(v)
-	}
-
-	return res
+	return v
 }

--- a/float32_slice_test.go
+++ b/float32_slice_test.go
@@ -29,8 +29,9 @@ func TestGetFloat32Slice(t *testing.T) {
 
 		t.Setenv("V1", "1.2,2.3,Three")
 
-		res := env.GetFloat32Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetFloat32Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyFloat32SliceWithDefault", func(t *testing.T) {

--- a/float32_slice_test.go
+++ b/float32_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -76,5 +77,33 @@ func TestMustGetFloat32Slice(t *testing.T) {
 
 		res := env.MustGetFloat32Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupFloat32Slice(t *testing.T) {
+	t.Run("LookupAbsentFloat32Slice", func(t *testing.T) {
+		_, err := env.LookupFloat32Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidFloat32Slice", func(t *testing.T) {
+		t.Setenv("V1", "1.1,2.2,3.3")
+
+		res, err := env.LookupFloat32Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []float32{1.1, 2.2, 3.3}, res)
+	})
+
+	t.Run("LookupInvalidFloat32Slice", func(t *testing.T) {
+		t.Setenv("V1", "1.1,2.2,Three")
+
+		_, err := env.LookupFloat32Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/float32_test.go
+++ b/float32_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -52,5 +53,34 @@ func TestMustGetFloat32(t *testing.T) {
 
 		res := env.MustGetFloat32("V1")
 		assertEqual(t, float32(14.5), res)
+	})
+}
+
+func TestLookupFloat32(t *testing.T) {
+	t.Run("LookupAbsentFloat32", func(t *testing.T) {
+		_, err := env.LookupFloat32("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidFloat32", func(t *testing.T) {
+		t.Setenv("V1", "14.5")
+
+		res, err := env.LookupFloat32("V1")
+		assertNoError(t, err)
+		assertEqual(t, float32(14.5), res)
+	})
+
+	t.Run("LookupInvalidFloat32", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupFloat32("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/float32_test.go
+++ b/float32_test.go
@@ -17,11 +17,9 @@ func TestGetFloat32(t *testing.T) {
 	t.Run("GetInvalidFloat32WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		def := float32(12.5)
-
-		res := env.GetFloat32("V1", def)
-
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetFloat32("V1", float32(12.5))
+		})
 	})
 
 	t.Run("GetValidFloat32WithDefault", func(t *testing.T) {

--- a/float64.go
+++ b/float64.go
@@ -1,36 +1,47 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetFloat64 extracts float64 value from env. If not set, returns default value.
-func GetFloat64(key string, def float64) float64 {
+// LookupFloat64 extracts float64 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupFloat64(key string) (float64, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseFloat(s, bitSize64)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return v
+	return v, nil
+}
+
+// GetFloat64 extracts float64 value from env. If not set, returns default value.
+func GetFloat64(key string, def float64) float64 {
+	v, err := LookupFloat64(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetFloat64 extracts float64 value from env. If not set, it panics.
 func MustGetFloat64(key string) float64 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseFloat(s, bitSize64)
+	v, err := LookupFloat64(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
 	return v

--- a/float64.go
+++ b/float64.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetFloat64 extracts int value from env. if not set, returns default value.
+// GetFloat64 extracts float64 value from env. If not set, returns default value.
 func GetFloat64(key string, def float64) float64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetFloat64(key string, def float64) float64 {
 
 	v, err := strconv.ParseFloat(s, bitSize64)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return v
 }
 
-// MustGetFloat64 extracts int value from env. if not set, it panics.
+// MustGetFloat64 extracts float64 value from env. If not set, it panics.
 func MustGetFloat64(key string) float64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseFloat(s, bitSize64)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return v

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// GetFloat64Slice extracts slice of float64 value with the format "1.2,2.3,3.4" from env.
-// if not set, returns default value.
+// GetFloat64Slice extracts slice of float64 values with the format "1.2,2.3,3.4" from env.
+// If not set, returns default value.
 func GetFloat64Slice(key string, def []float64) []float64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -26,7 +26,7 @@ func GetFloat64Slice(key string, def []float64) []float64 {
 	for i := range ss {
 		v, err := strconv.ParseFloat(ss[i], bitSize64)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = v
@@ -35,11 +35,11 @@ func GetFloat64Slice(key string, def []float64) []float64 {
 	return res
 }
 
-// MustGetFloat64Slice extracts slice of float64 value with the format "1.2,2.3,3.4" from env. if not set, it panics.
+// MustGetFloat64Slice extracts slice of float64 values with the format "1.2,2.3,3.4" from env. If not set, it panics.
 func MustGetFloat64Slice(key string) []float64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -53,7 +53,7 @@ func MustGetFloat64Slice(key string) []float64 {
 	for i := range ss {
 		v, err := strconv.ParseFloat(ss[i], bitSize64)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = v

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -1,22 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetFloat64Slice extracts slice of float64 values with the format "1.2,2.3,3.4" from env.
-// If not set, returns default value.
-func GetFloat64Slice(key string, def []float64) []float64 {
+// LookupFloat64Slice extracts slice of float64 values with the format "1.2,2.3,3.4" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupFloat64Slice(key string) ([]float64, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []float64{}
+		return []float64{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -26,38 +26,37 @@ func GetFloat64Slice(key string, def []float64) []float64 {
 	for i := range ss {
 		v, err := strconv.ParseFloat(ss[i], bitSize64)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = v
 	}
 
-	return res
+	return res, nil
+}
+
+// GetFloat64Slice extracts slice of float64 values with the format "1.2,2.3,3.4" from env.
+// If not set, returns default value.
+func GetFloat64Slice(key string, def []float64) []float64 {
+	v, err := LookupFloat64Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetFloat64Slice extracts slice of float64 values with the format "1.2,2.3,3.4" from env. If not set, it panics.
 func MustGetFloat64Slice(key string) []float64 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupFloat64Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []float64{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]float64, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseFloat(ss[i], bitSize64)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = v
-	}
-
-	return res
+	return v
 }

--- a/float64_slice_test.go
+++ b/float64_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetFloat64Slice(t *testing.T) {
 
 		res := env.MustGetFloat64Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupFloat64Slice(t *testing.T) {
+	t.Run("LookupAbsentFloat64Slice", func(t *testing.T) {
+		_, err := env.LookupFloat64Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidFloat64Slice", func(t *testing.T) {
+		t.Setenv("V1", "1.1,2.2,3.3")
+
+		res, err := env.LookupFloat64Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []float64{1.1, 2.2, 3.3}, res)
+	})
+
+	t.Run("LookupInvalidFloat64Slice", func(t *testing.T) {
+		t.Setenv("V1", "1.1,2.2,Three")
+
+		_, err := env.LookupFloat64Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/float64_slice_test.go
+++ b/float64_slice_test.go
@@ -26,8 +26,9 @@ func TestGetFloat64Slice(t *testing.T) {
 	t.Run("GetInvalidFloat64SliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1.2,2.3,Three")
 
-		res := env.GetFloat64Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetFloat64Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyFloat64SliceWithDefault", func(t *testing.T) {

--- a/float64_test.go
+++ b/float64_test.go
@@ -17,8 +17,9 @@ func TestGetFloat64(t *testing.T) {
 	t.Run("GetInvalidFloat64WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetFloat64("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetFloat64("V1", def)
+		})
 	})
 
 	t.Run("GetValidFloat64WithDefault", func(t *testing.T) {

--- a/float64_test.go
+++ b/float64_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -50,5 +51,34 @@ func TestMustGetFloat64(t *testing.T) {
 
 		res := env.MustGetFloat64("V1")
 		assertEqual(t, 14.5, res)
+	})
+}
+
+func TestLookupFloat64(t *testing.T) {
+	t.Run("LookupAbsentFloat64", func(t *testing.T) {
+		_, err := env.LookupFloat64("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidFloat64", func(t *testing.T) {
+		t.Setenv("V1", "14.5")
+
+		res, err := env.LookupFloat64("V1")
+		assertNoError(t, err)
+		assertEqual(t, 14.5, res)
+	})
+
+	t.Run("LookupInvalidFloat64", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupFloat64("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/generic.go
+++ b/generic.go
@@ -1,7 +1,7 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -16,132 +16,121 @@ type Type interface {
 
 // Get extracts value from env based on its type. If not set, returns default value.
 func Get[T Type](key string, def T) T {
-	var v T
-
-	switch t := any(v).(type) {
-	case bool:
-		return any(GetBool(key, any(def).(bool))).(T)
-	case float32:
-		return any(GetFloat32(key, any(def).(float32))).(T)
-	case []float32:
-		return any(GetFloat32Slice(key, any(def).([]float32))).(T)
-	case float64:
-		return any(GetFloat64(key, any(def).(float64))).(T)
-	case []float64:
-		return any(GetFloat64Slice(key, any(def).([]float64))).(T)
-	case int:
-		return any(GetInt(key, any(def).(int))).(T)
-	case []int:
-		return any(GetIntSlice(key, any(def).([]int))).(T)
-	case int8:
-		return any(GetInt8(key, any(def).(int8))).(T)
-	case []int8:
-		return any(GetInt8Slice(key, any(def).([]int8))).(T)
-	case int16:
-		return any(GetInt16(key, any(def).(int16))).(T)
-	case []int16:
-		return any(GetInt16Slice(key, any(def).([]int16))).(T)
-	case int32:
-		return any(GetInt32(key, any(def).(int32))).(T)
-	case []int32:
-		return any(GetInt32Slice(key, any(def).([]int32))).(T)
-	case int64:
-		return any(GetInt64(key, any(def).(int64))).(T)
-	case []int64:
-		return any(GetInt64Slice(key, any(def).([]int64))).(T)
-	case string:
-		return any(GetString(key, any(def).(string))).(T)
-	case []string:
-		return any(GetStringSlice(key, any(def).([]string))).(T)
-	case time.Duration:
-		return any(GetDuration(key, any(def).(time.Duration))).(T)
-	case uint:
-		return any(GetUint(key, any(def).(uint))).(T)
-	case []uint:
-		return any(GetUintSlice(key, any(def).([]uint))).(T)
-	case uint8:
-		return any(GetUint8(key, any(def).(uint8))).(T)
-	case []uint8:
-		return any(GetUint8Slice(key, any(def).([]uint8))).(T)
-	case uint16:
-		return any(GetUint16(key, any(def).(uint16))).(T)
-	case []uint16:
-		return any(GetUint16Slice(key, any(def).([]uint16))).(T)
-	case uint32:
-		return any(GetUint32(key, any(def).(uint32))).(T)
-	case []uint32:
-		return any(GetUint32Slice(key, any(def).([]uint32))).(T)
-	case uint64:
-		return any(GetUint64(key, any(def).(uint64))).(T)
-	case []uint64:
-		return any(GetUint64Slice(key, any(def).([]uint64))).(T)
-	default:
-		panic(fmt.Sprintf("type '%T' is not supported", t))
+	v, err := Lookup[T](key)
+	if err == nil {
+		return v
 	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGet extracts value from env based on its type. If not set, it panics.
 func MustGet[T Type](key string) T {
+	v, err := Lookup[T](key)
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// Lookup extracts value from env based on its type.
+// If not set, returns zero value and NotSetError.
+// If the value cannot be parsed, returns zero value and InvalidValueError.
+func Lookup[T Type](key string) (res T, err error) {
 	var v T
 
-	switch t := any(v).(type) {
+	switch any(v).(type) {
 	case bool:
-		return any(MustGetBool(key)).(T)
+		r, e := LookupBool(key)
+		res, err = any(r).(T), e
 	case float32:
-		return any(MustGetFloat32(key)).(T)
+		r, e := LookupFloat32(key)
+		res, err = any(r).(T), e
 	case []float32:
-		return any(MustGetFloat32Slice(key)).(T)
+		r, e := LookupFloat32Slice(key)
+		res, err = any(r).(T), e
 	case float64:
-		return any(MustGetFloat64(key)).(T)
+		r, e := LookupFloat64(key)
+		res, err = any(r).(T), e
 	case []float64:
-		return any(MustGetFloat64Slice(key)).(T)
+		r, e := LookupFloat64Slice(key)
+		res, err = any(r).(T), e
 	case int:
-		return any(MustGetInt(key)).(T)
+		r, e := LookupInt(key)
+		res, err = any(r).(T), e
 	case []int:
-		return any(MustGetIntSlice(key)).(T)
+		r, e := LookupIntSlice(key)
+		res, err = any(r).(T), e
 	case int8:
-		return any(MustGetInt8(key)).(T)
+		r, e := LookupInt8(key)
+		res, err = any(r).(T), e
 	case []int8:
-		return any(MustGetInt8Slice(key)).(T)
+		r, e := LookupInt8Slice(key)
+		res, err = any(r).(T), e
 	case int16:
-		return any(MustGetInt16(key)).(T)
+		r, e := LookupInt16(key)
+		res, err = any(r).(T), e
 	case []int16:
-		return any(MustGetInt16Slice(key)).(T)
+		r, e := LookupInt16Slice(key)
+		res, err = any(r).(T), e
 	case int32:
-		return any(MustGetInt32(key)).(T)
+		r, e := LookupInt32(key)
+		res, err = any(r).(T), e
 	case []int32:
-		return any(MustGetInt32Slice(key)).(T)
+		r, e := LookupInt32Slice(key)
+		res, err = any(r).(T), e
 	case int64:
-		return any(MustGetInt64(key)).(T)
+		r, e := LookupInt64(key)
+		res, err = any(r).(T), e
 	case []int64:
-		return any(MustGetInt64Slice(key)).(T)
+		r, e := LookupInt64Slice(key)
+		res, err = any(r).(T), e
 	case string:
-		return any(MustGetString(key)).(T)
+		r, e := LookupString(key)
+		res, err = any(r).(T), e
 	case []string:
-		return any(MustGetStringSlice(key)).(T)
+		r, e := LookupStringSlice(key)
+		res, err = any(r).(T), e
 	case time.Duration:
-		return any(MustGetDuration(key)).(T)
+		r, e := LookupDuration(key)
+		res, err = any(r).(T), e
 	case uint:
-		return any(MustGetUint(key)).(T)
+		r, e := LookupUint(key)
+		res, err = any(r).(T), e
 	case []uint:
-		return any(MustGetUintSlice(key)).(T)
+		r, e := LookupUintSlice(key)
+		res, err = any(r).(T), e
 	case uint8:
-		return any(MustGetUint8(key)).(T)
+		r, e := LookupUint8(key)
+		res, err = any(r).(T), e
 	case []uint8:
-		return any(MustGetUint8Slice(key)).(T)
+		r, e := LookupUint8Slice(key)
+		res, err = any(r).(T), e
 	case uint16:
-		return any(MustGetUint16(key)).(T)
+		r, e := LookupUint16(key)
+		res, err = any(r).(T), e
 	case []uint16:
-		return any(MustGetUint16Slice(key)).(T)
+		r, e := LookupUint16Slice(key)
+		res, err = any(r).(T), e
 	case uint32:
-		return any(MustGetUint32(key)).(T)
+		r, e := LookupUint32(key)
+		res, err = any(r).(T), e
 	case []uint32:
-		return any(MustGetUint32Slice(key)).(T)
+		r, e := LookupUint32Slice(key)
+		res, err = any(r).(T), e
 	case uint64:
-		return any(MustGetUint64(key)).(T)
+		r, e := LookupUint64(key)
+		res, err = any(r).(T), e
 	case []uint64:
-		return any(MustGetUint64Slice(key)).(T)
-	default:
-		panic(fmt.Sprintf("type '%T' is not supported", t))
+		r, e := LookupUint64Slice(key)
+		res, err = any(r).(T), e
 	}
+
+	return
 }

--- a/generic.go
+++ b/generic.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"fmt"
+	"time"
 )
 
 type Type interface {
@@ -9,10 +10,11 @@ type Type interface {
 		float32 | []float32 | float64 | []float64 |
 		int | []int | int8 | []int8 | int16 | []int16 | int32 | []int32 | int64 | []int64 |
 		string | []string |
+		time.Duration |
 		uint | []uint | uint8 | []uint8 | uint16 | []uint16 | uint32 | []uint32 | uint64 | []uint64
 }
 
-// Get extracts value from env based on its type. if not set, returns default value.
+// Get extracts value from env based on its type. If not set, returns default value.
 func Get[T Type](key string, def T) T {
 	var v T
 
@@ -51,6 +53,8 @@ func Get[T Type](key string, def T) T {
 		return any(GetString(key, any(def).(string))).(T)
 	case []string:
 		return any(GetStringSlice(key, any(def).([]string))).(T)
+	case time.Duration:
+		return any(GetDuration(key, any(def).(time.Duration))).(T)
 	case uint:
 		return any(GetUint(key, any(def).(uint))).(T)
 	case []uint:
@@ -76,7 +80,7 @@ func Get[T Type](key string, def T) T {
 	}
 }
 
-// MustGet extracts string value from env based on its type. if not set, it panics.
+// MustGet extracts value from env based on its type. If not set, it panics.
 func MustGet[T Type](key string) T {
 	var v T
 
@@ -115,6 +119,8 @@ func MustGet[T Type](key string) T {
 		return any(MustGetString(key)).(T)
 	case []string:
 		return any(MustGetStringSlice(key)).(T)
+	case time.Duration:
+		return any(MustGetDuration(key)).(T)
 	case uint:
 		return any(MustGetUint(key)).(T)
 	case []uint:

--- a/generic.go
+++ b/generic.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// Type is a constraint that includes all supported types by env package.
 type Type interface {
 	bool |
 		float32 | []float32 | float64 | []float64 |
@@ -132,5 +133,5 @@ func Lookup[T Type](key string) (res T, err error) {
 		res, err = any(r).(T), e
 	}
 
-	return
+	return //nolint:nakedret
 }

--- a/generic_test.go
+++ b/generic_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -42,8 +43,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetEmptyAsBoolWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "")
 
-			res := env.Get("V1", false)
-			assertTrue(t, res)
+			assertPanics(t, func() {
+				env.Get("V1", false)
+			})
 		})
 
 		t.Run("GetOneAsBoolWithDefault", func(t *testing.T) {
@@ -1705,6 +1707,371 @@ func TestMustGet(t *testing.T) {
 			assertPanics(t, func() {
 				env.MustGet[time.Duration]("V1")
 			})
+		})
+	}
+}
+
+func TestLookup(t *testing.T) {
+	// bool
+	{
+		t.Run("LookupAbsentBool", func(t *testing.T) {
+			_, err := env.Lookup[bool]("V1")
+
+			var notSetErr env.NotSetError
+			assertTrue(t, errors.As(err, &notSetErr))
+		})
+
+		t.Run("LookupValidBool", func(t *testing.T) {
+			t.Setenv("V1", "true")
+
+			res, err := env.Lookup[bool]("V1")
+			assertNoError(t, err)
+			assertTrue(t, res)
+		})
+
+		t.Run("LookupInvalidBool", func(t *testing.T) {
+			t.Setenv("V1", "invalid")
+
+			_, err := env.Lookup[bool]("V1")
+
+			var invalidValueErr env.InvalidValueError
+			assertTrue(t, errors.As(err, &invalidValueErr))
+		})
+	}
+
+	// string
+	{
+		t.Run("LookupAbsentString", func(t *testing.T) {
+			_, err := env.Lookup[string]("V1")
+
+			var notSetErr env.NotSetError
+			assertTrue(t, errors.As(err, &notSetErr))
+		})
+
+		t.Run("LookupValidString", func(t *testing.T) {
+			t.Setenv("V1", "hello")
+
+			res, err := env.Lookup[string]("V1")
+			assertNoError(t, err)
+			assertEqual(t, "hello", res)
+		})
+	}
+
+	// int
+	{
+		t.Run("LookupAbsentInt", func(t *testing.T) {
+			_, err := env.Lookup[int]("V1")
+
+			var notSetErr env.NotSetError
+			assertTrue(t, errors.As(err, &notSetErr))
+		})
+
+		t.Run("LookupValidInt", func(t *testing.T) {
+			t.Setenv("V1", "14")
+
+			res, err := env.Lookup[int]("V1")
+			assertNoError(t, err)
+			assertEqual(t, 14, res)
+		})
+
+		t.Run("LookupInvalidInt", func(t *testing.T) {
+			t.Setenv("V1", "invalid")
+
+			_, err := env.Lookup[int]("V1")
+
+			var invalidValueErr env.InvalidValueError
+			assertTrue(t, errors.As(err, &invalidValueErr))
+		})
+	}
+
+	// time.Duration
+	{
+		t.Run("LookupAbsentDuration", func(t *testing.T) {
+			_, err := env.Lookup[time.Duration]("V1")
+
+			var notSetErr env.NotSetError
+			assertTrue(t, errors.As(err, &notSetErr))
+		})
+
+		t.Run("LookupValidDuration", func(t *testing.T) {
+			t.Setenv("V1", "2s")
+
+			res, err := env.Lookup[time.Duration]("V1")
+			assertNoError(t, err)
+			assertEqual(t, 2*time.Second, res)
+		})
+
+		t.Run("LookupInvalidDuration", func(t *testing.T) {
+			t.Setenv("V1", "invalid")
+
+			_, err := env.Lookup[time.Duration]("V1")
+
+			var invalidValueErr env.InvalidValueError
+			assertTrue(t, errors.As(err, &invalidValueErr))
+		})
+	}
+
+	// float32
+	{
+		t.Run("LookupValidFloat32", func(t *testing.T) {
+			t.Setenv("V1", "1.5")
+
+			res, err := env.Lookup[float32]("V1")
+			assertNoError(t, err)
+			assertEqual(t, float32(1.5), res)
+		})
+	}
+
+	// []float32
+	{
+		t.Run("LookupValidFloat32Slice", func(t *testing.T) {
+			t.Setenv("V1", "1.5,2.5")
+
+			res, err := env.Lookup[[]float32]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []float32{1.5, 2.5}, res)
+		})
+	}
+
+	// float64
+	{
+		t.Run("LookupValidFloat64", func(t *testing.T) {
+			t.Setenv("V1", "1.5")
+
+			res, err := env.Lookup[float64]("V1")
+			assertNoError(t, err)
+			assertEqual(t, float64(1.5), res)
+		})
+	}
+
+	// []float64
+	{
+		t.Run("LookupValidFloat64Slice", func(t *testing.T) {
+			t.Setenv("V1", "1.5,2.5")
+
+			res, err := env.Lookup[[]float64]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []float64{1.5, 2.5}, res)
+		})
+	}
+
+	// []int
+	{
+		t.Run("LookupValidIntSlice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]int]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []int{1, 2, 3}, res)
+		})
+	}
+
+	// int8
+	{
+		t.Run("LookupValidInt8", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[int8]("V1")
+			assertNoError(t, err)
+			assertEqual(t, int8(42), res)
+		})
+	}
+
+	// []int8
+	{
+		t.Run("LookupValidInt8Slice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]int8]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []int8{1, 2, 3}, res)
+		})
+	}
+
+	// int16
+	{
+		t.Run("LookupValidInt16", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[int16]("V1")
+			assertNoError(t, err)
+			assertEqual(t, int16(42), res)
+		})
+	}
+
+	// []int16
+	{
+		t.Run("LookupValidInt16Slice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]int16]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []int16{1, 2, 3}, res)
+		})
+	}
+
+	// int32
+	{
+		t.Run("LookupValidInt32", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[int32]("V1")
+			assertNoError(t, err)
+			assertEqual(t, int32(42), res)
+		})
+	}
+
+	// []int32
+	{
+		t.Run("LookupValidInt32Slice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]int32]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []int32{1, 2, 3}, res)
+		})
+	}
+
+	// int64
+	{
+		t.Run("LookupValidInt64", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[int64]("V1")
+			assertNoError(t, err)
+			assertEqual(t, int64(42), res)
+		})
+	}
+
+	// []int64
+	{
+		t.Run("LookupValidInt64Slice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]int64]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []int64{1, 2, 3}, res)
+		})
+	}
+
+	// []string
+	{
+		t.Run("LookupValidStringSlice", func(t *testing.T) {
+			t.Setenv("V1", "foo,bar")
+
+			res, err := env.Lookup[[]string]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []string{"foo", "bar"}, res)
+		})
+	}
+
+	// uint
+	{
+		t.Run("LookupValidUint", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[uint]("V1")
+			assertNoError(t, err)
+			assertEqual(t, uint(42), res)
+		})
+	}
+
+	// []uint
+	{
+		t.Run("LookupValidUintSlice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]uint]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []uint{1, 2, 3}, res)
+		})
+	}
+
+	// uint8
+	{
+		t.Run("LookupValidUint8", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[uint8]("V1")
+			assertNoError(t, err)
+			assertEqual(t, uint8(42), res)
+		})
+	}
+
+	// []uint8
+	{
+		t.Run("LookupValidUint8Slice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]uint8]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []uint8{1, 2, 3}, res)
+		})
+	}
+
+	// uint16
+	{
+		t.Run("LookupValidUint16", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[uint16]("V1")
+			assertNoError(t, err)
+			assertEqual(t, uint16(42), res)
+		})
+	}
+
+	// []uint16
+	{
+		t.Run("LookupValidUint16Slice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]uint16]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []uint16{1, 2, 3}, res)
+		})
+	}
+
+	// uint32
+	{
+		t.Run("LookupValidUint32", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[uint32]("V1")
+			assertNoError(t, err)
+			assertEqual(t, uint32(42), res)
+		})
+	}
+
+	// []uint32
+	{
+		t.Run("LookupValidUint32Slice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]uint32]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []uint32{1, 2, 3}, res)
+		})
+	}
+
+	// uint64
+	{
+		t.Run("LookupValidUint64", func(t *testing.T) {
+			t.Setenv("V1", "42")
+
+			res, err := env.Lookup[uint64]("V1")
+			assertNoError(t, err)
+			assertEqual(t, uint64(42), res)
+		})
+	}
+
+	// []uint64
+	{
+		t.Run("LookupValidUint64Slice", func(t *testing.T) {
+			t.Setenv("V1", "1,2,3")
+
+			res, err := env.Lookup[[]uint64]("V1")
+			assertNoError(t, err)
+			assertEqualSlices(t, []uint64{1, 2, 3}, res)
 		})
 	}
 }

--- a/generic_test.go
+++ b/generic_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nasermirzaei89/env"
 )
@@ -65,9 +66,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidFloat32WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidFloat32WithDefault", func(t *testing.T) {
@@ -100,8 +101,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidFloat32SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1.2,2.3,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyFloat32SliceWithDefault", func(t *testing.T) {
@@ -126,8 +128,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidFloat64WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidFloat64WithDefault", func(t *testing.T) {
@@ -159,8 +162,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidFloat64SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1.2,2.3,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyFloat64SliceWithDefault", func(t *testing.T) {
@@ -185,8 +189,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidIntWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidIntWithDefault", func(t *testing.T) {
@@ -218,8 +223,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidIntSliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyIntSliceWithDefault", func(t *testing.T) {
@@ -244,8 +250,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidInt8WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidInt8WithDefault", func(t *testing.T) {
@@ -280,8 +287,9 @@ func TestGet(t *testing.T) {
 
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetInvalidInt8SliceWithDefault2", func(t *testing.T) {
@@ -289,8 +297,9 @@ func TestGet(t *testing.T) {
 
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyInt8SliceWithDefault", func(t *testing.T) {
@@ -316,8 +325,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidInt16WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidInt16WithDefault", func(t *testing.T) {
@@ -349,8 +359,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidInt16SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyInt16SliceWithDefault", func(t *testing.T) {
@@ -375,9 +386,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidInt32WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidInt32WithDefault", func(t *testing.T) {
@@ -410,8 +421,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidInt32SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyInt32SliceWithDefault", func(t *testing.T) {
@@ -436,8 +448,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidInt64WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidInt64WithDefault", func(t *testing.T) {
@@ -469,8 +482,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidInt64SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyInt64SliceWithDefault", func(t *testing.T) {
@@ -538,8 +552,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUIntWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidUIntWithDefault", func(t *testing.T) {
@@ -571,8 +586,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUIntSliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyUIntSliceWithDefault", func(t *testing.T) {
@@ -597,8 +613,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUInt8WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidUInt8WithDefault", func(t *testing.T) {
@@ -630,8 +647,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUInt8SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetInvalidUInt8SliceWithDefault2", func(t *testing.T) {
@@ -656,8 +674,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUInt16WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidUInt16WithDefault", func(t *testing.T) {
@@ -689,8 +708,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUInt16SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyUInt16SliceWithDefault", func(t *testing.T) {
@@ -715,8 +735,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUInt32WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidUInt32WithDefault", func(t *testing.T) {
@@ -748,8 +769,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUInt32SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyUInt32SliceWithDefault", func(t *testing.T) {
@@ -774,8 +796,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUInt64WithDefault", func(t *testing.T) {
 			t.Setenv("V1", "invalid")
 
-			res := env.Get("V1", def)
-			assertEqual(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetValidUInt64WithDefault", func(t *testing.T) {
@@ -807,8 +830,9 @@ func TestGet(t *testing.T) {
 		t.Run("GetInvalidUInt64SliceWithDefault", func(t *testing.T) {
 			t.Setenv("V1", "1,2,Three")
 
-			res := env.Get("V1", def)
-			assertEqualSlices(t, def, res)
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 
 		t.Run("GetEmptyUInt64SliceWithDefault", func(t *testing.T) {
@@ -818,6 +842,31 @@ func TestGet(t *testing.T) {
 
 			res := env.Get("V1", def)
 			assertEqualSlices(t, expected, res)
+		})
+	}
+
+	// time.Duration
+	{
+		def := time.Second
+
+		t.Run("GetAbsentDurationWithDefault", func(t *testing.T) {
+			res := env.Get("V1", def)
+			assertEqual(t, def, res)
+		})
+
+		t.Run("GetValidDurationWithDefault", func(t *testing.T) {
+			t.Setenv("V1", "2s")
+
+			res := env.Get("V1", def)
+			assertEqual(t, 2*time.Second, res)
+		})
+
+		t.Run("GetInvalidDurationWithDefault", func(t *testing.T) {
+			t.Setenv("V1", "invalid")
+
+			assertPanics(t, func() {
+				env.Get("V1", def)
+			})
 		})
 	}
 }
@@ -1632,6 +1681,30 @@ func TestMustGet(t *testing.T) {
 
 			res := env.MustGet[[]uint64]("V1")
 			assertEqualSlices(t, expected, res)
+		})
+	}
+
+	// time.Duration
+	{
+		t.Run("MustGetAbsentDuration", func(t *testing.T) {
+			assertPanics(t, func() {
+				env.MustGet[time.Duration]("V1")
+			})
+		})
+
+		t.Run("MustGetValidDuration", func(t *testing.T) {
+			t.Setenv("V1", "2s")
+
+			res := env.MustGet[time.Duration]("V1")
+			assertEqual(t, 2*time.Second, res)
+		})
+
+		t.Run("MustGetInvalidDuration", func(t *testing.T) {
+			t.Setenv("V1", "invalid")
+
+			assertPanics(t, func() {
+				env.MustGet[time.Duration]("V1")
+			})
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/nasermirzaei89/env
 
-go 1.18
+go 1.21

--- a/int.go
+++ b/int.go
@@ -1,36 +1,47 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetInt extracts int value from env. If not set, returns default value.
-func GetInt(key string, def int) int {
+// LookupInt extracts int value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupInt(key string) (int, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.Atoi(s)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return v
+	return v, nil
+}
+
+// GetInt extracts int value from env. If not set, returns default value.
+func GetInt(key string, def int) int {
+	v, err := LookupInt(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt extracts int value from env. If not set, it panics.
 func MustGetInt(key string) int {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.Atoi(s)
+	v, err := LookupInt(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
 	return v

--- a/int.go
+++ b/int.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetInt extracts int value from env. if not set, returns default value.
+// GetInt extracts int value from env. If not set, returns default value.
 func GetInt(key string, def int) int {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetInt(key string, def int) int {
 
 	v, err := strconv.Atoi(s)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return v
 }
 
-// MustGetInt extracts int value from env. if not set, it panics.
+// MustGetInt extracts int value from env. If not set, it panics.
 func MustGetInt(key string) int {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.Atoi(s)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return v

--- a/int16.go
+++ b/int16.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetInt16 extracts int16 value from env. if not set, returns default value.
+// GetInt16 extracts int16 value from env. If not set, returns default value.
 func GetInt16(key string, def int16) int16 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetInt16(key string, def int16) int16 {
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize16)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return int16(v)
 }
 
-// MustGetInt16 extracts int16 value from env. if not set, it panics.
+// MustGetInt16 extracts int16 value from env. If not set, it panics.
 func MustGetInt16(key string) int16 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize16)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return int16(v)

--- a/int16.go
+++ b/int16.go
@@ -1,37 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetInt16 extracts int16 value from env. If not set, returns default value.
-func GetInt16(key string, def int16) int16 {
+// LookupInt16 extracts int16 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupInt16(key string) (int16, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize16)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return int16(v)
+	return int16(v), nil
+}
+
+// GetInt16 extracts int16 value from env. If not set, returns default value.
+func GetInt16(key string, def int16) int16 {
+	v, err := LookupInt16(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt16 extracts int16 value from env. If not set, it panics.
 func MustGetInt16(key string) int16 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseInt(s, decimalBase, bitSize16)
+	v, err := LookupInt16(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
-	return int16(v)
+	return v
 }

--- a/int16_slice.go
+++ b/int16_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetInt16Slice extracts slice of int16 value with the format "1,2,3" from env. if not set, returns default value.
+// GetInt16Slice extracts slice of int16 values with the format "1,2,3" from env. If not set, returns default value.
 func GetInt16Slice(key string, def []int16) []int16 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetInt16Slice(key string, def []int16) []int16 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize16)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = int16(v)
@@ -34,11 +34,11 @@ func GetInt16Slice(key string, def []int16) []int16 {
 	return res
 }
 
-// MustGetInt16Slice extracts slice of int16 value with the format "1,2,3" from env. if not set, it panics.
+// MustGetInt16Slice extracts slice of int16 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetInt16Slice(key string) []int16 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetInt16Slice(key string) []int16 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize16)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = int16(v)

--- a/int16_slice.go
+++ b/int16_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetInt16Slice extracts slice of int16 values with the format "1,2,3" from env. If not set, returns default value.
-func GetInt16Slice(key string, def []int16) []int16 {
+// LookupInt16Slice extracts slice of int16 values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupInt16Slice(key string) ([]int16, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []int16{}
+		return []int16{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetInt16Slice(key string, def []int16) []int16 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize16)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = int16(v)
 	}
 
-	return res
+	return res, nil
+}
+
+// GetInt16Slice extracts slice of int16 values with the format "1,2,3" from env. If not set, returns default value.
+func GetInt16Slice(key string, def []int16) []int16 {
+	v, err := LookupInt16Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt16Slice extracts slice of int16 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetInt16Slice(key string) []int16 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupInt16Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []int16{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]int16, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize16)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = int16(v)
-	}
-
-	return res
+	return v
 }

--- a/int16_slice_test.go
+++ b/int16_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetInt16Slice(t *testing.T) {
 
 		res := env.MustGetInt16Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupInt16Slice(t *testing.T) {
+	t.Run("LookupAbsentInt16Slice", func(t *testing.T) {
+		_, err := env.LookupInt16Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt16Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupInt16Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []int16{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidInt16Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupInt16Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/int16_slice_test.go
+++ b/int16_slice_test.go
@@ -26,8 +26,9 @@ func TestGetInt16Slice(t *testing.T) {
 	t.Run("GetInvalidInt16SliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetInt16Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt16Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyInt16SliceWithDefault", func(t *testing.T) {

--- a/int16_test.go
+++ b/int16_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -50,5 +51,34 @@ func TestMustGetInt16(t *testing.T) {
 
 		res := env.MustGetInt16("V1")
 		assertEqual(t, int16(14), res)
+	})
+}
+
+func TestLookupInt16(t *testing.T) {
+	t.Run("LookupAbsentInt16", func(t *testing.T) {
+		_, err := env.LookupInt16("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt16", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupInt16("V1")
+		assertNoError(t, err)
+		assertEqual(t, int16(14), res)
+	})
+
+	t.Run("LookupInvalidInt16", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupInt16("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/int16_test.go
+++ b/int16_test.go
@@ -17,8 +17,9 @@ func TestGetInt16(t *testing.T) {
 	t.Run("GetInvalidInt16WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetInt16("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt16("V1", def)
+		})
 	})
 
 	t.Run("GetValidInt16WithDefault", func(t *testing.T) {

--- a/int32.go
+++ b/int32.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetInt32 extracts int32 value from env. if not set, returns default value.
+// GetInt32 extracts int32 value from env. If not set, returns default value.
 func GetInt32(key string, def int32) int32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetInt32(key string, def int32) int32 {
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize32)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return int32(v)
 }
 
-// MustGetInt32 extracts int32 value from env. if not set, it panics.
+// MustGetInt32 extracts int32 value from env. If not set, it panics.
 func MustGetInt32(key string) int32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize32)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return int32(v)

--- a/int32.go
+++ b/int32.go
@@ -1,37 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetInt32 extracts int32 value from env. If not set, returns default value.
-func GetInt32(key string, def int32) int32 {
+// LookupInt32 extracts int32 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupInt32(key string) (int32, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize32)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return int32(v)
+	return int32(v), nil
+}
+
+// GetInt32 extracts int32 value from env. If not set, returns default value.
+func GetInt32(key string, def int32) int32 {
+	v, err := LookupInt32(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt32 extracts int32 value from env. If not set, it panics.
 func MustGetInt32(key string) int32 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseInt(s, decimalBase, bitSize32)
+	v, err := LookupInt32(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
-	return int32(v)
+	return v
 }

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetInt32Slice extracts slice of int32 values with the format "1,2,3" from env. If not set, returns default value.
-func GetInt32Slice(key string, def []int32) []int32 {
+// LookupInt32Slice extracts slice of int32 values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupInt32Slice(key string) ([]int32, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []int32{}
+		return []int32{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetInt32Slice(key string, def []int32) []int32 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize32)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = int32(v)
 	}
 
-	return res
+	return res, nil
+}
+
+// GetInt32Slice extracts slice of int32 values with the format "1,2,3" from env. If not set, returns default value.
+func GetInt32Slice(key string, def []int32) []int32 {
+	v, err := LookupInt32Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt32Slice extracts slice of int32 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetInt32Slice(key string) []int32 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupInt32Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []int32{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]int32, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize32)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = int32(v)
-	}
-
-	return res
+	return v
 }

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetInt32Slice extracts slice of int32 value with the format "1,2,3" from env. if not set, returns default value.
+// GetInt32Slice extracts slice of int32 values with the format "1,2,3" from env. If not set, returns default value.
 func GetInt32Slice(key string, def []int32) []int32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetInt32Slice(key string, def []int32) []int32 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize32)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = int32(v)
@@ -34,11 +34,11 @@ func GetInt32Slice(key string, def []int32) []int32 {
 	return res
 }
 
-// MustGetInt32Slice extracts slice of int32 value with the format "1,2,3" from env. if not set, it panics.
+// MustGetInt32Slice extracts slice of int32 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetInt32Slice(key string) []int32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetInt32Slice(key string) []int32 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize32)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = int32(v)

--- a/int32_slice_test.go
+++ b/int32_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetInt32Slice(t *testing.T) {
 
 		res := env.MustGetInt32Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupInt32Slice(t *testing.T) {
+	t.Run("LookupAbsentInt32Slice", func(t *testing.T) {
+		_, err := env.LookupInt32Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt32Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupInt32Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []int32{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidInt32Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupInt32Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/int32_slice_test.go
+++ b/int32_slice_test.go
@@ -26,8 +26,9 @@ func TestGetInt32Slice(t *testing.T) {
 	t.Run("GetInvalidInt32SliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetInt32Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt32Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyInt32SliceWithDefault", func(t *testing.T) {

--- a/int32_test.go
+++ b/int32_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -50,5 +51,34 @@ func TestMustGetInt32(t *testing.T) {
 
 		res := env.MustGetInt32("V1")
 		assertEqual(t, int32(14), res)
+	})
+}
+
+func TestLookupInt32(t *testing.T) {
+	t.Run("LookupAbsentInt32", func(t *testing.T) {
+		_, err := env.LookupInt32("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt32", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupInt32("V1")
+		assertNoError(t, err)
+		assertEqual(t, int32(14), res)
+	})
+
+	t.Run("LookupInvalidInt32", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupInt32("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/int32_test.go
+++ b/int32_test.go
@@ -17,8 +17,9 @@ func TestGetInt32(t *testing.T) {
 	t.Run("GetInvalidInt32WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetInt32("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt32("V1", def)
+		})
 	})
 
 	t.Run("GetValidInt32WithDefault", func(t *testing.T) {

--- a/int64.go
+++ b/int64.go
@@ -1,36 +1,47 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetInt64 extracts int64 value from env. If not set, returns default value.
-func GetInt64(key string, def int64) int64 {
+// LookupInt64 extracts int64 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupInt64(key string) (int64, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize64)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return v
+	return v, nil
+}
+
+// GetInt64 extracts int64 value from env. If not set, returns default value.
+func GetInt64(key string, def int64) int64 {
+	v, err := LookupInt64(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt64 extracts int64 value from env. If not set, it panics.
 func MustGetInt64(key string) int64 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseInt(s, decimalBase, bitSize64)
+	v, err := LookupInt64(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
 	return v

--- a/int64.go
+++ b/int64.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetInt64 extracts int64 value from env. if not set, returns default value.
+// GetInt64 extracts int64 value from env. If not set, returns default value.
 func GetInt64(key string, def int64) int64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetInt64(key string, def int64) int64 {
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize64)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return v
 }
 
-// MustGetInt64 extracts int64 value from env. if not set, it panics.
+// MustGetInt64 extracts int64 value from env. If not set, it panics.
 func MustGetInt64(key string) int64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize64)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return v

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetInt64Slice extracts slice of int64 values with the format "1,2,3" from env. If not set, returns default value.
-func GetInt64Slice(key string, def []int64) []int64 {
+// LookupInt64Slice extracts slice of int64 values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupInt64Slice(key string) ([]int64, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []int64{}
+		return []int64{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetInt64Slice(key string, def []int64) []int64 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = v
 	}
 
-	return res
+	return res, nil
+}
+
+// GetInt64Slice extracts slice of int64 values with the format "1,2,3" from env. If not set, returns default value.
+func GetInt64Slice(key string, def []int64) []int64 {
+	v, err := LookupInt64Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt64Slice extracts slice of int64 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetInt64Slice(key string) []int64 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupInt64Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []int64{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]int64, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize64)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = v
-	}
-
-	return res
+	return v
 }

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetInt64Slice extracts slice of int64 value with the format "1,2,3" from env. if not set, returns default value.
+// GetInt64Slice extracts slice of int64 values with the format "1,2,3" from env. If not set, returns default value.
 func GetInt64Slice(key string, def []int64) []int64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetInt64Slice(key string, def []int64) []int64 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = v
@@ -34,11 +34,11 @@ func GetInt64Slice(key string, def []int64) []int64 {
 	return res
 }
 
-// MustGetInt64Slice extracts slice of int64 value with the format "1,2,3" from env. if not set, it panics.
+// MustGetInt64Slice extracts slice of int64 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetInt64Slice(key string) []int64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetInt64Slice(key string) []int64 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = v

--- a/int64_slice_test.go
+++ b/int64_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetInt64Slice(t *testing.T) {
 
 		res := env.MustGetInt64Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupInt64Slice(t *testing.T) {
+	t.Run("LookupAbsentInt64Slice", func(t *testing.T) {
+		_, err := env.LookupInt64Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt64Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupInt64Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []int64{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidInt64Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupInt64Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/int64_slice_test.go
+++ b/int64_slice_test.go
@@ -26,8 +26,9 @@ func TestGetInt64Slice(t *testing.T) {
 	t.Run("GetInvalidInt64SliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetInt64Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt64Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyInt64SliceWithDefault", func(t *testing.T) {

--- a/int64_test.go
+++ b/int64_test.go
@@ -17,8 +17,9 @@ func TestGetInt64(t *testing.T) {
 	t.Run("GetInvalidInt64WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetInt64("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt64("V1", def)
+		})
 	})
 
 	t.Run("GetValidInt64WithDefault", func(t *testing.T) {

--- a/int64_test.go
+++ b/int64_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -49,5 +50,34 @@ func TestMustGetInt64(t *testing.T) {
 
 		res := env.MustGetInt64("V1")
 		assertEqual(t, int64(14), res)
+	})
+}
+
+func TestLookupInt64(t *testing.T) {
+	t.Run("LookupAbsentInt64", func(t *testing.T) {
+		_, err := env.LookupInt64("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt64", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupInt64("V1")
+		assertNoError(t, err)
+		assertEqual(t, int64(14), res)
+	})
+
+	t.Run("LookupInvalidInt64", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupInt64("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/int8.go
+++ b/int8.go
@@ -1,37 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetInt8 extracts int8 value from env. If not set, returns default value.
-func GetInt8(key string, def int8) int8 {
+// LookupInt8 extracts int8 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupInt8(key string) (int8, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize8)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return int8(v)
+	return int8(v), nil
+}
+
+// GetInt8 extracts int8 value from env. If not set, returns default value.
+func GetInt8(key string, def int8) int8 {
+	v, err := LookupInt8(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt8 extracts int8 value from env. If not set, it panics.
 func MustGetInt8(key string) int8 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseInt(s, decimalBase, bitSize8)
+	v, err := LookupInt8(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
-	return int8(v)
+	return v
 }

--- a/int8.go
+++ b/int8.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetInt8 extracts int8 value from env. if not set, returns default value.
+// GetInt8 extracts int8 value from env. If not set, returns default value.
 func GetInt8(key string, def int8) int8 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetInt8(key string, def int8) int8 {
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize8)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return int8(v)
 }
 
-// MustGetInt8 extracts int8 value from env. if not set, it panics.
+// MustGetInt8 extracts int8 value from env. If not set, it panics.
 func MustGetInt8(key string) int8 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseInt(s, decimalBase, bitSize8)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return int8(v)

--- a/int8_slice.go
+++ b/int8_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetInt8Slice extracts slice of int8 value with the format "1,2,3" from env. if not set, returns default value.
+// GetInt8Slice extracts slice of int8 values with the format "1,2,3" from env. If not set, returns default value.
 func GetInt8Slice(key string, def []int8) []int8 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetInt8Slice(key string, def []int8) []int8 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize8)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = int8(v)
@@ -34,11 +34,11 @@ func GetInt8Slice(key string, def []int8) []int8 {
 	return res
 }
 
-// MustGetInt8Slice extracts slice of int8 value with the format "1,2,3" from env. if not set, it panics.
+// MustGetInt8Slice extracts slice of int8 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetInt8Slice(key string) []int8 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetInt8Slice(key string) []int8 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize8)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = int8(v)

--- a/int8_slice.go
+++ b/int8_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetInt8Slice extracts slice of int8 values with the format "1,2,3" from env. If not set, returns default value.
-func GetInt8Slice(key string, def []int8) []int8 {
+// LookupInt8Slice extracts slice of int8 values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupInt8Slice(key string) ([]int8, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []int8{}
+		return []int8{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetInt8Slice(key string, def []int8) []int8 {
 	for i := range ss {
 		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize8)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = int8(v)
 	}
 
-	return res
+	return res, nil
+}
+
+// GetInt8Slice extracts slice of int8 values with the format "1,2,3" from env. If not set, returns default value.
+func GetInt8Slice(key string, def []int8) []int8 {
+	v, err := LookupInt8Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetInt8Slice extracts slice of int8 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetInt8Slice(key string) []int8 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupInt8Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []int8{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]int8, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseInt(ss[i], decimalBase, bitSize8)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = int8(v)
-	}
-
-	return res
+	return v
 }

--- a/int8_slice_test.go
+++ b/int8_slice_test.go
@@ -29,8 +29,9 @@ func TestGetInt8Slice(t *testing.T) {
 
 		t.Setenv("V1", "invalid")
 
-		res := env.GetInt8Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt8Slice("V1", def)
+		})
 	})
 
 	t.Run("GetInvalidInt8SliceWithDefault2", func(t *testing.T) {
@@ -38,8 +39,9 @@ func TestGetInt8Slice(t *testing.T) {
 
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetInt8Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt8Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyInt8SliceWithDefault", func(t *testing.T) {

--- a/int8_slice_test.go
+++ b/int8_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -86,5 +87,33 @@ func TestMustGetInt8Slice(t *testing.T) {
 
 		res := env.MustGetInt8Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupInt8Slice(t *testing.T) {
+	t.Run("LookupAbsentInt8Slice", func(t *testing.T) {
+		_, err := env.LookupInt8Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt8Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupInt8Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []int8{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidInt8Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupInt8Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/int8_test.go
+++ b/int8_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -49,5 +50,34 @@ func TestMustGetInt8(t *testing.T) {
 
 		res := env.MustGetInt8("V1")
 		assertEqual(t, int8(14), res)
+	})
+}
+
+func TestLookupInt8(t *testing.T) {
+	t.Run("LookupAbsentInt8", func(t *testing.T) {
+		_, err := env.LookupInt8("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt8", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupInt8("V1")
+		assertNoError(t, err)
+		assertEqual(t, int8(14), res)
+	})
+
+	t.Run("LookupInvalidInt8", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupInt8("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/int8_test.go
+++ b/int8_test.go
@@ -17,8 +17,9 @@ func TestGetInt8(t *testing.T) {
 	t.Run("GetInvalidInt8WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetInt8("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt8("V1", def)
+		})
 	})
 
 	t.Run("GetValidInt8WithDefault", func(t *testing.T) {

--- a/int_slice.go
+++ b/int_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetIntSlice extracts slice of int value with the format "1,2,3" from env. if not set, returns default value.
+// GetIntSlice extracts slice of int values with the format "1,2,3" from env. If not set, returns default value.
 func GetIntSlice(key string, def []int) []int {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetIntSlice(key string, def []int) []int {
 	for i := range ss {
 		v, err := strconv.Atoi(ss[i])
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = v
@@ -34,11 +34,11 @@ func GetIntSlice(key string, def []int) []int {
 	return res
 }
 
-// MustGetIntSlice extracts slice of int value with the format "1,2,3" from env. if not set, it panics.
+// MustGetIntSlice extracts slice of int values with the format "1,2,3" from env. If not set, it panics.
 func MustGetIntSlice(key string) []int {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetIntSlice(key string) []int {
 	for i := range ss {
 		v, err := strconv.Atoi(ss[i])
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = v

--- a/int_slice.go
+++ b/int_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetIntSlice extracts slice of int values with the format "1,2,3" from env. If not set, returns default value.
-func GetIntSlice(key string, def []int) []int {
+// LookupIntSlice extracts slice of int values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupIntSlice(key string) ([]int, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []int{}
+		return []int{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetIntSlice(key string, def []int) []int {
 	for i := range ss {
 		v, err := strconv.Atoi(ss[i])
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = v
 	}
 
-	return res
+	return res, nil
+}
+
+// GetIntSlice extracts slice of int values with the format "1,2,3" from env. If not set, returns default value.
+func GetIntSlice(key string, def []int) []int {
+	v, err := LookupIntSlice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetIntSlice extracts slice of int values with the format "1,2,3" from env. If not set, it panics.
 func MustGetIntSlice(key string) []int {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupIntSlice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []int{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]int, len(ss))
-
-	for i := range ss {
-		v, err := strconv.Atoi(ss[i])
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = v
-	}
-
-	return res
+	return v
 }

--- a/int_slice_test.go
+++ b/int_slice_test.go
@@ -26,8 +26,9 @@ func TestGetIntSlice(t *testing.T) {
 	t.Run("GetInvalidIntSliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetIntSlice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetIntSlice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyIntSliceWithDefault", func(t *testing.T) {

--- a/int_slice_test.go
+++ b/int_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetIntSlice(t *testing.T) {
 
 		res := env.MustGetIntSlice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupIntSlice(t *testing.T) {
+	t.Run("LookupAbsentIntSlice", func(t *testing.T) {
+		_, err := env.LookupIntSlice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidIntSlice", func(t *testing.T) {
+		t.Setenv("V1", "31,32,33")
+
+		res, err := env.LookupIntSlice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []int{31, 32, 33}, res)
+	})
+
+	t.Run("LookupInvalidIntSlice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupIntSlice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/int_test.go
+++ b/int_test.go
@@ -17,8 +17,9 @@ func TestGetInt(t *testing.T) {
 	t.Run("GetInvalidIntWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetInt("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetInt("V1", def)
+		})
 	})
 
 	t.Run("GetValidIntWithDefault", func(t *testing.T) {

--- a/int_test.go
+++ b/int_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -49,5 +50,34 @@ func TestMustGetInt(t *testing.T) {
 
 		res := env.MustGetInt("V1")
 		assertEqual(t, 14, res)
+	})
+}
+
+func TestLookupInt(t *testing.T) {
+	t.Run("LookupAbsentInt", func(t *testing.T) {
+		_, err := env.LookupInt("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidInt", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupInt("V1")
+		assertNoError(t, err)
+		assertEqual(t, 14, res)
+	})
+
+	t.Run("LookupInvalidInt", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupInt("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/string.go
+++ b/string.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-// GetString extracts string value from env. if not set, returns default value.
+// GetString extracts string value from env. If not set, returns default value.
 func GetString(key, def string) string {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,11 +15,11 @@ func GetString(key, def string) string {
 	return s
 }
 
-// MustGetString extracts string value from env. if not set, it panics.
+// MustGetString extracts string value from env. If not set, it panics.
 func MustGetString(key string) string {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' has not been set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	return s

--- a/string.go
+++ b/string.go
@@ -1,26 +1,35 @@
 package env
 
 import (
-	"fmt"
 	"os"
 )
 
-// GetString extracts string value from env. If not set, returns default value.
-func GetString(key, def string) string {
+// LookupString extracts string value from env. If not set, returns NotSetError.
+func LookupString(key string) (string, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
+		return "", NotSetError{Key: key}
+	}
+
+	return s, nil
+}
+
+// GetString extracts string value from env. If not set, returns default value.
+func GetString(key, def string) string {
+	v, err := LookupString(key)
+	if err != nil {
 		return def
 	}
 
-	return s
+	return v
 }
 
 // MustGetString extracts string value from env. If not set, it panics.
 func MustGetString(key string) string {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupString(key)
+	if err != nil {
+		panic(err)
 	}
 
-	return s
+	return v
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -1,37 +1,43 @@
 package env
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
 
-// GetStringSlice extracts slice of string values with format "foo,bar,baz" from env.
-// If not set, returns default value.
-func GetStringSlice(key string, def []string) []string {
+// LookupStringSlice extracts slice of string values with format "foo,bar,baz" from env.
+// If not set, returns NotSetError.
+func LookupStringSlice(key string) ([]string, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if len(s) == 0 {
-		return []string{}
+		return []string{}, nil
 	}
 
-	return strings.Split(s, ",")
+	return strings.Split(s, ","), nil
+}
+
+// GetStringSlice extracts slice of string values with format "foo,bar,baz" from env.
+// If not set, returns default value.
+func GetStringSlice(key string, def []string) []string {
+	v, err := LookupStringSlice(key)
+	if err != nil {
+		return def
+	}
+
+	return v
 }
 
 // MustGetStringSlice extracts slice of string values with format "foo,bar,baz" from env.
 // If not set, it panics.
 func MustGetStringSlice(key string) []string {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupStringSlice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if len(s) == 0 {
-		return []string{}
-	}
-
-	return strings.Split(s, ",")
+	return v
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-// GetStringSlice extracts slice of strings value with format "foo,bar,baz" from env.
-// if not set, returns default value.
+// GetStringSlice extracts slice of string values with format "foo,bar,baz" from env.
+// If not set, returns default value.
 func GetStringSlice(key string, def []string) []string {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -21,12 +21,12 @@ func GetStringSlice(key string, def []string) []string {
 	return strings.Split(s, ",")
 }
 
-// MustGetStringSlice extracts slice of strings value with format "foo,bar,baz" from env.
-// if not set, it panics.
+// MustGetStringSlice extracts slice of string values with format "foo,bar,baz" from env.
+// If not set, it panics.
 func MustGetStringSlice(key string) []string {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' has not been set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if len(s) == 0 {

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -52,6 +53,25 @@ func TestMustGetStringSlice(t *testing.T) {
 		t.Setenv("V1", strings.Join(expected, ","))
 
 		res := env.MustGetStringSlice("V1")
+		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupStringSlice(t *testing.T) {
+	t.Run("LookupAbsentStringSlice", func(t *testing.T) {
+		_, err := env.LookupStringSlice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidStringSlice", func(t *testing.T) {
+		expected := []string{"foo", "bar", "baz"}
+		t.Setenv("V1", strings.Join(expected, ","))
+
+		res, err := env.LookupStringSlice("V1")
+		assertNoError(t, err)
 		assertEqualSlices(t, expected, res)
 	})
 }

--- a/string_test.go
+++ b/string_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -33,6 +34,24 @@ func TestMustGetString(t *testing.T) {
 		t.Setenv("V1", "val")
 
 		res := env.MustGetString("V1")
+		assertEqual(t, "val", res)
+	})
+}
+
+func TestLookupString(t *testing.T) {
+	t.Run("LookupAbsentString", func(t *testing.T) {
+		_, err := env.LookupString("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidString", func(t *testing.T) {
+		t.Setenv("V1", "val")
+
+		res, err := env.LookupString("V1")
+		assertNoError(t, err)
 		assertEqual(t, "val", res)
 	})
 }

--- a/uint.go
+++ b/uint.go
@@ -1,11 +1,39 @@
 package env
 
+import "errors"
+
+// LookupUint extracts uint value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupUint(key string) (uint, error) {
+	v, err := LookupUint64(key)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint(v), nil
+}
+
 // GetUint extracts uint value from env. If not set, returns default value.
 func GetUint(key string, def uint) uint {
-	return uint(GetUint64(key, uint64(def)))
+	v, err := LookupUint(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint extracts uint value from env. If not set, it panics.
 func MustGetUint(key string) uint {
-	return uint(MustGetUint64(key))
+	v, err := LookupUint(key)
+	if err != nil {
+		panic(err)
+	}
+
+	return v
 }

--- a/uint.go
+++ b/uint.go
@@ -1,11 +1,11 @@
 package env
 
-// GetUint extracts uint value from env. if not set, returns default value.
+// GetUint extracts uint value from env. If not set, returns default value.
 func GetUint(key string, def uint) uint {
 	return uint(GetUint64(key, uint64(def)))
 }
 
-// MustGetUint extracts uint value from env. if not set, it panics.
+// MustGetUint extracts uint value from env. If not set, it panics.
 func MustGetUint(key string) uint {
 	return uint(MustGetUint64(key))
 }

--- a/uint16.go
+++ b/uint16.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetUint16 extracts uint16 value from env. if not set, returns default value.
+// GetUint16 extracts uint16 value from env. If not set, returns default value.
 func GetUint16(key string, def uint16) uint16 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetUint16(key string, def uint16) uint16 {
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize16)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return uint16(v)
 }
 
-// MustGetUint16 extracts uint16 value from env. if not set, it panics.
+// MustGetUint16 extracts uint16 value from env. If not set, it panics.
 func MustGetUint16(key string) uint16 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize16)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return uint16(v)

--- a/uint16.go
+++ b/uint16.go
@@ -1,37 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetUint16 extracts uint16 value from env. If not set, returns default value.
-func GetUint16(key string, def uint16) uint16 {
+// LookupUint16 extracts uint16 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupUint16(key string) (uint16, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize16)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return uint16(v)
+	return uint16(v), nil
+}
+
+// GetUint16 extracts uint16 value from env. If not set, returns default value.
+func GetUint16(key string, def uint16) uint16 {
+	v, err := LookupUint16(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint16 extracts uint16 value from env. If not set, it panics.
 func MustGetUint16(key string) uint16 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseUint(s, decimalBase, bitSize16)
+	v, err := LookupUint16(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
-	return uint16(v)
+	return v
 }

--- a/uint16_slice.go
+++ b/uint16_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetUint16Slice extracts slice of uint16 values with the format "1,2,3" from env. If not set, returns default value.
-func GetUint16Slice(key string, def []uint16) []uint16 {
+// LookupUint16Slice extracts slice of uint16 values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupUint16Slice(key string) ([]uint16, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []uint16{}
+		return []uint16{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetUint16Slice(key string, def []uint16) []uint16 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize16)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = uint16(v)
 	}
 
-	return res
+	return res, nil
+}
+
+// GetUint16Slice extracts slice of uint16 values with the format "1,2,3" from env. If not set, returns default value.
+func GetUint16Slice(key string, def []uint16) []uint16 {
+	v, err := LookupUint16Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint16Slice extracts slice of uint16 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUint16Slice(key string) []uint16 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupUint16Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []uint16{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]uint16, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize16)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = uint16(v)
-	}
-
-	return res
+	return v
 }

--- a/uint16_slice.go
+++ b/uint16_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetUint16Slice extracts slice of uint16 value with the format "1,2,3" from env. if not set, returns default value.
+// GetUint16Slice extracts slice of uint16 values with the format "1,2,3" from env. If not set, returns default value.
 func GetUint16Slice(key string, def []uint16) []uint16 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetUint16Slice(key string, def []uint16) []uint16 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize16)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = uint16(v)
@@ -34,11 +34,11 @@ func GetUint16Slice(key string, def []uint16) []uint16 {
 	return res
 }
 
-// MustGetUint16Slice extracts slice of uint16 value with the format "1,2,3" from env. if not set, it panics.
+// MustGetUint16Slice extracts slice of uint16 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUint16Slice(key string) []uint16 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetUint16Slice(key string) []uint16 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize16)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = uint16(v)

--- a/uint16_slice_test.go
+++ b/uint16_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetUint16Slice(t *testing.T) {
 
 		res := env.MustGetUint16Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupUint16Slice(t *testing.T) {
+	t.Run("LookupAbsentUint16Slice", func(t *testing.T) {
+		_, err := env.LookupUint16Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint16Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupUint16Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []uint16{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidUint16Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupUint16Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/uint16_slice_test.go
+++ b/uint16_slice_test.go
@@ -26,8 +26,9 @@ func TestGetUint16Slice(t *testing.T) {
 	t.Run("GetInvalidUInt16SliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetUint16Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint16Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyUInt16SliceWithDefault", func(t *testing.T) {

--- a/uint16_test.go
+++ b/uint16_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -49,5 +50,34 @@ func TestMustGetUint16(t *testing.T) {
 
 		res := env.MustGetUint16("V1")
 		assertEqual(t, uint16(14), res)
+	})
+}
+
+func TestLookupUint16(t *testing.T) {
+	t.Run("LookupAbsentUint16", func(t *testing.T) {
+		_, err := env.LookupUint16("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint16", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupUint16("V1")
+		assertNoError(t, err)
+		assertEqual(t, uint16(14), res)
+	})
+
+	t.Run("LookupInvalidUint16", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupUint16("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/uint16_test.go
+++ b/uint16_test.go
@@ -17,8 +17,9 @@ func TestGetUint16(t *testing.T) {
 	t.Run("GetInvalidUInt16WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetUint16("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint16("V1", def)
+		})
 	})
 
 	t.Run("GetValidUInt16WithDefault", func(t *testing.T) {

--- a/uint32.go
+++ b/uint32.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetUint32 extracts uint32 value from env. if not set, returns default value.
+// GetUint32 extracts uint32 value from env. If not set, returns default value.
 func GetUint32(key string, def uint32) uint32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetUint32(key string, def uint32) uint32 {
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize32)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return uint32(v)
 }
 
-// MustGetUint32 extracts uint32 value from env. if not set, it panics.
+// MustGetUint32 extracts uint32 value from env. If not set, it panics.
 func MustGetUint32(key string) uint32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize32)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return uint32(v)

--- a/uint32.go
+++ b/uint32.go
@@ -1,37 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetUint32 extracts uint32 value from env. If not set, returns default value.
-func GetUint32(key string, def uint32) uint32 {
+// LookupUint32 extracts uint32 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupUint32(key string) (uint32, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize32)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return uint32(v)
+	return uint32(v), nil
+}
+
+// GetUint32 extracts uint32 value from env. If not set, returns default value.
+func GetUint32(key string, def uint32) uint32 {
+	v, err := LookupUint32(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint32 extracts uint32 value from env. If not set, it panics.
 func MustGetUint32(key string) uint32 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseUint(s, decimalBase, bitSize32)
+	v, err := LookupUint32(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
-	return uint32(v)
+	return v
 }

--- a/uint32_slice.go
+++ b/uint32_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetUint32Slice extracts slice of uint32 values with the format "1,2,3" from env. If not set, returns default value.
-func GetUint32Slice(key string, def []uint32) []uint32 {
+// LookupUint32Slice extracts slice of uint32 values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupUint32Slice(key string) ([]uint32, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []uint32{}
+		return []uint32{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetUint32Slice(key string, def []uint32) []uint32 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize32)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = uint32(v)
 	}
 
-	return res
+	return res, nil
+}
+
+// GetUint32Slice extracts slice of uint32 values with the format "1,2,3" from env. If not set, returns default value.
+func GetUint32Slice(key string, def []uint32) []uint32 {
+	v, err := LookupUint32Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint32Slice extracts slice of uint32 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUint32Slice(key string) []uint32 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupUint32Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []uint32{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]uint32, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize32)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = uint32(v)
-	}
-
-	return res
+	return v
 }

--- a/uint32_slice.go
+++ b/uint32_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetUint32Slice extracts slice of uint32 value with the format "1,2,3" from env. if not set, returns default value.
+// GetUint32Slice extracts slice of uint32 values with the format "1,2,3" from env. If not set, returns default value.
 func GetUint32Slice(key string, def []uint32) []uint32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetUint32Slice(key string, def []uint32) []uint32 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize32)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = uint32(v)
@@ -34,11 +34,11 @@ func GetUint32Slice(key string, def []uint32) []uint32 {
 	return res
 }
 
-// MustGetUint32Slice extracts slice of uint32 value with the format "1,2,3" from env. if not set, it panics.
+// MustGetUint32Slice extracts slice of uint32 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUint32Slice(key string) []uint32 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetUint32Slice(key string) []uint32 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize32)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = uint32(v)

--- a/uint32_slice_test.go
+++ b/uint32_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetUint32Slice(t *testing.T) {
 
 		res := env.MustGetUint32Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupUint32Slice(t *testing.T) {
+	t.Run("LookupAbsentUint32Slice", func(t *testing.T) {
+		_, err := env.LookupUint32Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint32Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupUint32Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []uint32{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidUint32Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupUint32Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/uint32_slice_test.go
+++ b/uint32_slice_test.go
@@ -26,8 +26,9 @@ func TestGetUint32Slice(t *testing.T) {
 	t.Run("GetInvalidUInt32SliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetUint32Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint32Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyUInt32SliceWithDefault", func(t *testing.T) {

--- a/uint32_test.go
+++ b/uint32_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -49,5 +50,34 @@ func TestMustGetUint32(t *testing.T) {
 
 		res := env.MustGetUint32("V1")
 		assertEqual(t, uint32(14), res)
+	})
+}
+
+func TestLookupUint32(t *testing.T) {
+	t.Run("LookupAbsentUint32", func(t *testing.T) {
+		_, err := env.LookupUint32("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint32", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupUint32("V1")
+		assertNoError(t, err)
+		assertEqual(t, uint32(14), res)
+	})
+
+	t.Run("LookupInvalidUint32", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupUint32("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/uint32_test.go
+++ b/uint32_test.go
@@ -17,8 +17,9 @@ func TestGetUint32(t *testing.T) {
 	t.Run("GetInvalidUInt32WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetUint32("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint32("V1", def)
+		})
 	})
 
 	t.Run("GetValidUInt32WithDefault", func(t *testing.T) {

--- a/uint64.go
+++ b/uint64.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetUint64 extracts uint64 value from env. if not set, returns default value.
+// GetUint64 extracts uint64 value from env. If not set, returns default value.
 func GetUint64(key string, def uint64) uint64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetUint64(key string, def uint64) uint64 {
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize64)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return v
 }
 
-// MustGetUint64 extracts uint64 value from env. if not set, it panics.
+// MustGetUint64 extracts uint64 value from env. If not set, it panics.
 func MustGetUint64(key string) uint64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize64)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return v

--- a/uint64.go
+++ b/uint64.go
@@ -1,36 +1,47 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetUint64 extracts uint64 value from env. If not set, returns default value.
-func GetUint64(key string, def uint64) uint64 {
+// LookupUint64 extracts uint64 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupUint64(key string) (uint64, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize64)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return v
+	return v, nil
+}
+
+// GetUint64 extracts uint64 value from env. If not set, returns default value.
+func GetUint64(key string, def uint64) uint64 {
+	v, err := LookupUint64(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint64 extracts uint64 value from env. If not set, it panics.
 func MustGetUint64(key string) uint64 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseUint(s, decimalBase, bitSize64)
+	v, err := LookupUint64(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
 	return v

--- a/uint64_slice.go
+++ b/uint64_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetUint64Slice extracts slice of uint64 values with the format "1,2,3" from env. If not set, returns default value.
-func GetUint64Slice(key string, def []uint64) []uint64 {
+// LookupUint64Slice extracts slice of uint64 values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupUint64Slice(key string) ([]uint64, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []uint64{}
+		return []uint64{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetUint64Slice(key string, def []uint64) []uint64 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = v
 	}
 
-	return res
+	return res, nil
+}
+
+// GetUint64Slice extracts slice of uint64 values with the format "1,2,3" from env. If not set, returns default value.
+func GetUint64Slice(key string, def []uint64) []uint64 {
+	v, err := LookupUint64Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint64Slice extracts slice of uint64 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUint64Slice(key string) []uint64 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupUint64Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []uint64{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]uint64, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize64)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = v
-	}
-
-	return res
+	return v
 }

--- a/uint64_slice.go
+++ b/uint64_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetUint64Slice extracts slice of uint64 value with the format "1,2,3" from env. if not set, returns default value.
+// GetUint64Slice extracts slice of uint64 values with the format "1,2,3" from env. If not set, returns default value.
 func GetUint64Slice(key string, def []uint64) []uint64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetUint64Slice(key string, def []uint64) []uint64 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = v
@@ -34,11 +34,11 @@ func GetUint64Slice(key string, def []uint64) []uint64 {
 	return res
 }
 
-// MustGetUint64Slice extracts slice of uint64 value with the format "1,2,3" from env. if not set, it panics.
+// MustGetUint64Slice extracts slice of uint64 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUint64Slice(key string) []uint64 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetUint64Slice(key string) []uint64 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = v

--- a/uint64_slice_test.go
+++ b/uint64_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetUint64Slice(t *testing.T) {
 
 		res := env.MustGetUint64Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupUint64Slice(t *testing.T) {
+	t.Run("LookupAbsentUint64Slice", func(t *testing.T) {
+		_, err := env.LookupUint64Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint64Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupUint64Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []uint64{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidUint64Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupUint64Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/uint64_slice_test.go
+++ b/uint64_slice_test.go
@@ -26,8 +26,9 @@ func TestGetUint64Slice(t *testing.T) {
 	t.Run("GetInvalidUInt64SliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetUint64Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint64Slice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyUInt64SliceWithDefault", func(t *testing.T) {

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -49,5 +50,34 @@ func TestMustGetUint64(t *testing.T) {
 
 		res := env.MustGetUint64("V1")
 		assertEqual(t, uint64(14), res)
+	})
+}
+
+func TestLookupUint64(t *testing.T) {
+	t.Run("LookupAbsentUint64", func(t *testing.T) {
+		_, err := env.LookupUint64("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint64", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupUint64("V1")
+		assertNoError(t, err)
+		assertEqual(t, uint64(14), res)
+	})
+
+	t.Run("LookupInvalidUint64", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupUint64("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -17,8 +17,9 @@ func TestGetUint64(t *testing.T) {
 	t.Run("GetInvalidUInt64WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetUint64("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint64("V1", def)
+		})
 	})
 
 	t.Run("GetValidUInt64WithDefault", func(t *testing.T) {

--- a/uint8.go
+++ b/uint8.go
@@ -1,37 +1,48 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 )
 
-// GetUint8 extracts uint8 value from env. If not set, returns default value.
-func GetUint8(key string, def uint8) uint8 {
+// LookupUint8 extracts uint8 value from env. If not set, returns NotSetError.
+// If the value cannot be parsed, returns InvalidValueError.
+func LookupUint8(key string) (uint8, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return 0, NotSetError{Key: key}
 	}
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize8)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		return 0, InvalidValueError{Key: key, Value: s, Err: err}
 	}
 
-	return uint8(v)
+	return uint8(v), nil
+}
+
+// GetUint8 extracts uint8 value from env. If not set, returns default value.
+func GetUint8(key string, def uint8) uint8 {
+	v, err := LookupUint8(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint8 extracts uint8 value from env. If not set, it panics.
 func MustGetUint8(key string) uint8 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
-	}
-
-	v, err := strconv.ParseUint(s, decimalBase, bitSize8)
+	v, err := LookupUint8(key)
 	if err != nil {
-		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+		panic(err)
 	}
 
-	return uint8(v)
+	return v
 }

--- a/uint8.go
+++ b/uint8.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-// GetUint8 extracts uint8 value from env. if not set, returns default value.
+// GetUint8 extracts uint8 value from env. If not set, returns default value.
 func GetUint8(key string, def uint8) uint8 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -15,22 +15,22 @@ func GetUint8(key string, def uint8) uint8 {
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize8)
 	if err != nil {
-		return def
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return uint8(v)
 }
 
-// MustGetUint8 extracts uint8 value from env. if not set, it panics.
+// MustGetUint8 extracts uint8 value from env. If not set, it panics.
 func MustGetUint8(key string) uint8 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	v, err := strconv.ParseUint(s, decimalBase, bitSize8)
 	if err != nil {
-		panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+		panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 	}
 
 	return uint8(v)

--- a/uint8_slice.go
+++ b/uint8_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetUint8Slice extracts slice of uint8 value with the format "1,2,3" from env. if not set, returns default value.
+// GetUint8Slice extracts slice of uint8 values with the format "1,2,3" from env. If not set, returns default value.
 func GetUint8Slice(key string, def []uint8) []uint8 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetUint8Slice(key string, def []uint8) []uint8 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize8)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = uint8(v)
@@ -34,11 +34,11 @@ func GetUint8Slice(key string, def []uint8) []uint8 {
 	return res
 }
 
-// MustGetUint8Slice extracts slice of uint8 value with the format "1,2,3" from env. if not set, it panics.
+// MustGetUint8Slice extracts slice of uint8 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUint8Slice(key string) []uint8 {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetUint8Slice(key string) []uint8 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize8)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = uint8(v)

--- a/uint8_slice.go
+++ b/uint8_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetUint8Slice extracts slice of uint8 values with the format "1,2,3" from env. If not set, returns default value.
-func GetUint8Slice(key string, def []uint8) []uint8 {
+// LookupUint8Slice extracts slice of uint8 values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupUint8Slice(key string) ([]uint8, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []uint8{}
+		return []uint8{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetUint8Slice(key string, def []uint8) []uint8 {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize8)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = uint8(v)
 	}
 
-	return res
+	return res, nil
+}
+
+// GetUint8Slice extracts slice of uint8 values with the format "1,2,3" from env. If not set, returns default value.
+func GetUint8Slice(key string, def []uint8) []uint8 {
+	v, err := LookupUint8Slice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUint8Slice extracts slice of uint8 values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUint8Slice(key string) []uint8 {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupUint8Slice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []uint8{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]uint8, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize8)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = uint8(v)
-	}
-
-	return res
+	return v
 }

--- a/uint8_slice_test.go
+++ b/uint8_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetUint8Slice(t *testing.T) {
 
 		res := env.MustGetUint8Slice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupUint8Slice(t *testing.T) {
+	t.Run("LookupAbsentUint8Slice", func(t *testing.T) {
+		_, err := env.LookupUint8Slice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint8Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupUint8Slice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []uint8{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidUint8Slice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupUint8Slice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/uint8_slice_test.go
+++ b/uint8_slice_test.go
@@ -26,8 +26,9 @@ func TestGetUint8Slice(t *testing.T) {
 	t.Run("GetInvalidUInt8SliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetUint8Slice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint8Slice("V1", def)
+		})
 	})
 
 	t.Run("GetInvalidUInt8SliceWithDefault2", func(t *testing.T) {

--- a/uint8_test.go
+++ b/uint8_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -49,5 +50,34 @@ func TestMustGetUint8(t *testing.T) {
 
 		res := env.MustGetUint8("V1")
 		assertEqual(t, uint8(14), res)
+	})
+}
+
+func TestLookupUint8(t *testing.T) {
+	t.Run("LookupAbsentUint8", func(t *testing.T) {
+		_, err := env.LookupUint8("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint8", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupUint8("V1")
+		assertNoError(t, err)
+		assertEqual(t, uint8(14), res)
+	})
+
+	t.Run("LookupInvalidUint8", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupUint8("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/uint8_test.go
+++ b/uint8_test.go
@@ -17,8 +17,9 @@ func TestGetUint8(t *testing.T) {
 	t.Run("GetInvalidUInt8WithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetUint8("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint8("V1", def)
+		})
 	})
 
 	t.Run("GetValidUInt8WithDefault", func(t *testing.T) {

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -1,21 +1,22 @@
 package env
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// GetUintSlice extracts slice of uint values with the format "1,2,3" from env. If not set, returns default value.
-func GetUintSlice(key string, def []uint) []uint {
+// LookupUintSlice extracts slice of uint values with the format "1,2,3" from env.
+// If not set, returns NotSetError. If the value cannot be parsed, returns InvalidValueError.
+func LookupUintSlice(key string) ([]uint, error) {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		return def
+		return nil, NotSetError{Key: key}
 	}
 
 	if s == "" {
-		return []uint{}
+		return []uint{}, nil
 	}
 
 	ss := strings.Split(s, ",")
@@ -25,38 +26,36 @@ func GetUintSlice(key string, def []uint) []uint {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
+			return nil, InvalidValueError{Key: key, Value: s, Err: err}
 		}
 
 		res[i] = uint(v)
 	}
 
-	return res
+	return res, nil
+}
+
+// GetUintSlice extracts slice of uint values with the format "1,2,3" from env. If not set, returns default value.
+func GetUintSlice(key string, def []uint) []uint {
+	v, err := LookupUintSlice(key)
+	if err == nil {
+		return v
+	}
+
+	var notSetErr NotSetError
+	if errors.As(err, &notSetErr) {
+		return def
+	}
+
+	panic(err)
 }
 
 // MustGetUintSlice extracts slice of uint values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUintSlice(key string) []uint {
-	s, ok := os.LookupEnv(key)
-	if !ok {
-		panic(fmt.Sprintf("environment variable %q not set", key))
+	v, err := LookupUintSlice(key)
+	if err != nil {
+		panic(err)
 	}
 
-	if s == "" {
-		return []uint{}
-	}
-
-	ss := strings.Split(s, ",")
-
-	res := make([]uint, len(ss))
-
-	for i := range ss {
-		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize64)
-		if err != nil {
-			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
-		}
-
-		res[i] = uint(v)
-	}
-
-	return res
+	return v
 }

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// GetUintSlice extracts slice of uint value with the format "1,2,3" from env. if not set, returns default value.
+// GetUintSlice extracts slice of uint values with the format "1,2,3" from env. If not set, returns default value.
 func GetUintSlice(key string, def []uint) []uint {
 	s, ok := os.LookupEnv(key)
 	if !ok {
@@ -25,7 +25,7 @@ func GetUintSlice(key string, def []uint) []uint {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			return def
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = uint(v)
@@ -34,11 +34,11 @@ func GetUintSlice(key string, def []uint) []uint {
 	return res
 }
 
-// MustGetUintSlice extracts slice of uint value with the format "1,2,3" from env. if not set, it panics.
+// MustGetUintSlice extracts slice of uint values with the format "1,2,3" from env. If not set, it panics.
 func MustGetUintSlice(key string) []uint {
 	s, ok := os.LookupEnv(key)
 	if !ok {
-		panic(fmt.Sprintf("environment variable '%s' not set", key))
+		panic(fmt.Sprintf("environment variable %q not set", key))
 	}
 
 	if s == "" {
@@ -52,7 +52,7 @@ func MustGetUintSlice(key string) []uint {
 	for i := range ss {
 		v, err := strconv.ParseUint(ss[i], decimalBase, bitSize64)
 		if err != nil {
-			panic(fmt.Sprintf("invalid environment variable '%s' has been set: %s", key, s))
+			panic(fmt.Sprintf("environment variable %q has an invalid value: %q", key, s))
 		}
 
 		res[i] = uint(v)

--- a/uint_slice_test.go
+++ b/uint_slice_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -72,5 +73,33 @@ func TestMustGetUintSlice(t *testing.T) {
 
 		res := env.MustGetUintSlice("V1")
 		assertEqualSlices(t, expected, res)
+	})
+}
+
+func TestLookupUintSlice(t *testing.T) {
+	t.Run("LookupAbsentUintSlice", func(t *testing.T) {
+		_, err := env.LookupUintSlice("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUintSlice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,3")
+
+		res, err := env.LookupUintSlice("V1")
+		assertNoError(t, err)
+		assertEqualSlices(t, []uint{1, 2, 3}, res)
+	})
+
+	t.Run("LookupInvalidUintSlice", func(t *testing.T) {
+		t.Setenv("V1", "1,2,Three")
+
+		_, err := env.LookupUintSlice("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
 	})
 }

--- a/uint_slice_test.go
+++ b/uint_slice_test.go
@@ -26,8 +26,9 @@ func TestGetUintSlice(t *testing.T) {
 	t.Run("GetInvalidUIntSliceWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "1,2,Three")
 
-		res := env.GetUintSlice("V1", def)
-		assertEqualSlices(t, def, res)
+		assertPanics(t, func() {
+			env.GetUintSlice("V1", def)
+		})
 	})
 
 	t.Run("GetEmptyUIntSliceWithDefault", func(t *testing.T) {

--- a/uint_test.go
+++ b/uint_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nasermirzaei89/env"
@@ -49,5 +50,34 @@ func TestMustGetUint(t *testing.T) {
 
 		res := env.MustGetUint("V1")
 		assertEqual(t, uint(14), res)
+	})
+}
+
+func TestLookupUint(t *testing.T) {
+	t.Run("LookupAbsentUint", func(t *testing.T) {
+		_, err := env.LookupUint("V1")
+
+		var notSetErr env.NotSetError
+		assertTrue(t, errors.As(err, &notSetErr))
+		assertEqual(t, "V1", notSetErr.Key)
+	})
+
+	t.Run("LookupValidUint", func(t *testing.T) {
+		t.Setenv("V1", "14")
+
+		res, err := env.LookupUint("V1")
+		assertNoError(t, err)
+		assertEqual(t, uint(14), res)
+	})
+
+	t.Run("LookupInvalidUint", func(t *testing.T) {
+		t.Setenv("V1", "invalid")
+
+		_, err := env.LookupUint("V1")
+
+		var invalidValueErr env.InvalidValueError
+		assertTrue(t, errors.As(err, &invalidValueErr))
+		assertEqual(t, "V1", invalidValueErr.Key)
+		assertEqual(t, "invalid", invalidValueErr.Value)
 	})
 }

--- a/uint_test.go
+++ b/uint_test.go
@@ -17,8 +17,9 @@ func TestGetUint(t *testing.T) {
 	t.Run("GetInvalidUIntWithDefault", func(t *testing.T) {
 		t.Setenv("V1", "invalid")
 
-		res := env.GetUint("V1", def)
-		assertEqual(t, def, res)
+		assertPanics(t, func() {
+			env.GetUint("V1", def)
+		})
 	})
 
 	t.Run("GetValidUIntWithDefault", func(t *testing.T) {


### PR DESCRIPTION
This pull request introduces structured error handling for environment variable parsing, adds support for duration types, refactors existing parsing functions to use the new error types, and updates documentation and tests accordingly. It also modernizes some internal implementations and updates CI workflows for newer Go versions and actions.

**Structured error handling and new types:**
- Introduced `NotSetError` and `InvalidValueError` types for more precise error reporting when environment variables are missing or have invalid values. All `LookupXXX` functions now return these errors, and corresponding tests are added. (`errors.go` [[1]](diffhunk://#diff-76a7e0e299c7417bae32d3098e71370980157fe29e68a366671491d147d40572R1-R27) `errors_test.go` [[2]](diffhunk://#diff-5c4d3e0fb6348a54d285f0812da0b323800e6e8c5d30b93e92a40677a267810fR1-R47)
- Added support for durations with `LookupDuration`, `GetDuration`, and `MustGetDuration` functions, along with comprehensive tests and README documentation. (`duration.go` [[1]](diffhunk://#diff-a66713119bc13ffd06f7fa4ca498d7600cdba1caceb1f7f3c3e17aa1bde3e75fR1-R48) `duration_test.go` [[2]](diffhunk://#diff-71bd4726a1179b6a016ca3314f80e3b5d959237bd1a95c7cb4d2a1fa22f1b2f1R1-R77) `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R48) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R63) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R85-R140)

**Refactoring of existing parsing functions:**
- Refactored `GetBool`, `GetFloat32`, and `GetFloat32Slice` (and their `MustGet`/`Lookup` variants) to use the new error types and to panic only on truly unexpected errors, improving reliability and consistency. (`bool.go` [[1]](diffhunk://#diff-c4c6c7d52edb0158934eb0d4a81ecc752e1561aaaf48a6d01a6fb0058e4bb4abL4-R47) `float32.go` [[2]](diffhunk://#diff-419c7f3d422a72c0520e74906c0ea30d03bde5def84da3caba3b52adf86fba5cL4-R47) `float32_slice.go` [[3]](diffhunk://#diff-dd0d463a0cbbd390f3d64d4e5bb6db3853408370b8676438f105cee98bbf6983L4-R19)
- Updated and expanded corresponding tests to cover new error handling and edge cases. (`bool_test.go` [[1]](diffhunk://#diff-39d3babb47e5a6333cc9a29b01aedf91fcf797505e0798efb8e116f855301e34R4) [[2]](diffhunk://#diff-39d3babb47e5a6333cc9a29b01aedf91fcf797505e0798efb8e116f855301e34L39-R42) [[3]](diffhunk://#diff-39d3babb47e5a6333cc9a29b01aedf91fcf797505e0798efb8e116f855301e34R88-R116) `assert_test.go` [[4]](diffhunk://#diff-cc012cf4bc0e45c461f4aed072f95d1fcc2e597e76f03c7416ae51e55f4c0315R5) [[5]](diffhunk://#diff-cc012cf4bc0e45c461f4aed072f95d1fcc2e597e76f03c7416ae51e55f4c0315L37-R38) [[6]](diffhunk://#diff-cc012cf4bc0e45c461f4aed072f95d1fcc2e597e76f03c7416ae51e55f4c0315R53-R62)

**Internal improvements and code modernization:**
- Replaced manual slice comparison and environment checks with the standard `slices` package for cleaner, more efficient code. (`env.go` [[1]](diffhunk://#diff-901643e46196ff948ed22a0164ff057a898f5ec2c278edb5c8d905f369c929f0R5) [[2]](diffhunk://#diff-901643e46196ff948ed22a0164ff057a898f5ec2c278edb5c8d905f369c929f0L39-R32) `assert_test.go` [[3]](diffhunk://#diff-cc012cf4bc0e45c461f4aed072f95d1fcc2e597e76f03c7416ae51e55f4c0315R5) [[4]](diffhunk://#diff-cc012cf4bc0e45c461f4aed072f95d1fcc2e597e76f03c7416ae51e55f4c0315L37-R38)
- Moved constant definitions for bit sizes and decimal base to a dedicated file for clarity. (`const.go` [[1]](diffhunk://#diff-94dacef0ac41aa5d49ab2c28c5299940b98a347553b11239fc2be03f8e19e314R1-R9) `env.go` [[2]](diffhunk://#diff-901643e46196ff948ed22a0164ff057a898f5ec2c278edb5c8d905f369c929f0L18-L25)

**Documentation and usage examples:**
- Updated the `README.md` to document new duration functions, structured error handling, and examples for distinguishing between missing and invalid environment variables. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R48) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R63) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R85-R140)

**CI/CD and workflow updates:**
- Updated GitHub Actions workflows to use newer Go versions (1.21–1.26) and the latest actions for checkout, setup-go, and golangci-lint, ensuring compatibility and up-to-date linting. (`.github/workflows/build.yml` [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L2-R12) `.github/workflows/test.yml` [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L2-R12) `.github/workflows/lint.yml` [[3]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L2-R16)

These changes make the library more robust, user-friendly, and maintainable.